### PR TITLE
#82 Railwayにデプロイする

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,25 @@
+# Git
+.git
+.gitignore
+
+# ビルド成果物
+main
+*.test
+*.out
+
+# ログファイル
+*.log
+
+# 環境変数ファイル
+.env
+.env.local
+
+# Firebase秘密鍵（環境変数で渡すため）
+firebase-admin-key.json
+
+# ドキュメント
+*.md
+README.md
+
+# その他
+.DS_Store

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,16 +1,39 @@
 # ビルド用イメージ
 FROM golang:1.25-alpine AS builder
+
+# ビルドに必要なパッケージをインストール
+RUN apk add --no-cache git
+
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN go build -o main ./cmd/server/main.go
+
+# バイナリサイズを削減してビルド
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o main ./cmd/server/main.go
 
 # 実行用イメージ
-FROM alpine:latest
-WORKDIR /root/
-COPY --from=builder /app/main .
-# Firebaseの秘密鍵を環境変数から読み込む場合は不要だが、
-# もしファイルが必要な場合はここで調整
+FROM alpine:3.19
+
+# CA証明書をインストール（HTTPS通信に必要）
+RUN apk --no-cache add ca-certificates tzdata
+
+# 非rootユーザーを作成
+RUN addgroup -g 1001 -S appuser && \
+    adduser -u 1001 -S appuser -G appuser
+
+WORKDIR /home/appuser
+
+# ビルドしたバイナリをコピー
+COPY --from=builder --chown=appuser:appuser /app/main .
+
+# 非rootユーザーに切り替え
+USER appuser
+
 EXPOSE 8080
+
+# ヘルスチェック（Railway用）
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
+
 CMD ["./main"]


### PR DESCRIPTION
# バックエンドのRailwayデプロイ対応

## 概要
バックエンドAPIをRailwayにデプロイするための設定を追加しました。

## 変更内容

### 新規ファイル
- **Dockerfile**: マルチステージビルドによる本番環境用イメージ
- **.dockerignore**: ビルド時の不要ファイル除外

### Dockerfileの特徴
- **マルチステージビルド**: ビルド用と実行用でイメージを分離し、最終イメージサイズを削減
- **Alpine Linux**: 軽量な実行環境（最終イメージ約50MB以下）
- **セキュリティ対策**:
  - 非rootユーザー（appuser）で実行
  - CA証明書のインストール（HTTPS通信対応）
  - バージョン固定（alpine:3.19）で再現性確保
- **最適化**:
  - `-ldflags="-w -s"` でバイナリサイズ削減
  - `.dockerignore` でビルドコンテキスト最小化
- **監視対応**: HEALTHCHECKで `/health` エンドポイントを監視

### Railway設定（環境変数）
以下の環境変数を設定する必要があります：

```bash
# 必須
DATABASE_DSN=postgresql://...
FIREBASE_CREDENTIALS_JSON={"type":"service_account",...}
ALLOWED_ORIGINS=https://your-frontend-domain.com

# オプション
PORT=8080
ENV=production
```

## デプロイ手順

1. Railwayで新しいプロジェクトを作成
2. GitHub連携でリポジトリを接続
3. 環境変数を設定
4. 自動デプロイが実行される

## 動作確認

```bash
# ローカルでDockerビルド確認
docker build -t money-buddy-backend .

# ローカルで実行確認
docker run -p 8080:8080 \
  -e DATABASE_DSN="..." \
  -e FIREBASE_CREDENTIALS_JSON="..." \
  -e ALLOWED_ORIGINS="http://localhost:3000" \
  money-buddy-backend

# ヘルスチェック
curl http://localhost:8080/health
```

## 関連Issue
- Closes: #82