### PR TITLE
#84 データベース接続プール設定を追加（Neon対応）

### DIFF
--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -2,7 +2,9 @@ package db
 
 import (
 	"database/sql"
+	"log"
 	"os"
+	"time"
 
 	_ "github.com/lib/pq"
 )
@@ -12,5 +14,24 @@ func NewDB() (*sql.DB, error) {
 	if dsn == "" {
 		dsn = "host=localhost port=5432 user=appuser password=password dbname=expense_db sslmode=disable"
 	}
-	return sql.Open("postgres", dsn)
+
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	// コネクションプール設定（Neon対応）
+	db.SetMaxOpenConns(10)                 // 最大同時接続数（Neonの制限内）
+	db.SetMaxIdleConns(5)                  // アイドル接続数
+	db.SetConnMaxLifetime(5 * time.Minute) // 接続の最大寿命（Neonのタイムアウト対策）
+	db.SetConnMaxIdleTime(2 * time.Minute) // アイドル接続の最大時間
+
+	// 接続テスト
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, err
+	}
+
+	log.Println("Database connection established and tested successfully")
+	return db, nil
 }


### PR DESCRIPTION
## 概要
バックエンドAPIをRailwayにデプロイするための設定を追加し、Neon PostgreSQLとの接続を安定化させました。

## 変更内容

### 新規ファイル
- **Dockerfile**: マルチステージビルドによる本番環境用イメージ
- **.dockerignore**: ビルド時の不要ファイル除外

### 修正ファイル
- **db.go**: データベース接続プール設定を追加

---

## 主な改善

### 1. Dockerコンテナ対応

**Dockerfile:**
- **マルチステージビルド**: ビルド用と実行用でイメージを分離し、最終イメージサイズを削減
- **Alpine Linux**: 軽量な実行環境（最終イメージ約50MB以下）
- **セキュリティ対策**:
  - 非rootユーザー（appuser）で実行
  - CA証明書のインストール（HTTPS通信対応）
  - バージョン固定（alpine:3.19）で再現性確保
- **最適化**:
  - `-ldflags="-w -s"` でバイナリサイズ削減
  - `.dockerignore` でビルドコンテキスト最小化
- **監視対応**: HEALTHCHECKで `/health` エンドポイントを監視

### 2. データベース接続プール設定（Neon対応）

**問題:**
- デフォルト設定ではNeonの接続制限に達しやすい
- 接続タイムアウトでランダムにエラーが発生

**解決:**
```go
// コネクションプール設定
db.SetMaxOpenConns(10)                 // 最大同時接続数（Neonの制限内）
db.SetMaxIdleConns(5)                  // アイドル接続数
db.SetConnMaxLifetime(5 * time.Minute) // 接続の最大寿命
db.SetConnMaxIdleTime(2 * time.Minute) // アイドル接続の最大時間

// 起動時の接続テスト
if err := db.Ping(); err != nil {
    return nil, err
}
```

**効果:**
- 接続数を制御してNeonの制限を超えない
- アイドル接続を適切に管理
- 起動時に接続テストして早期エラー検出

---

## デプロイ設定

### Railway環境変数

以下の環境変数を設定してください：

```bash
# データベース（Neon Pooled Connection必須）
DATABASE_DSN=host=your-neon-pooler.neon.tech port=5432 user=xxx password=xxx dbname=xxx sslmode=require

# Firebase認証（JSON文字列推奨）
FIREBASE_CREDENTIALS_JSON={"type":"service_account","project_id":"your-project",...}

# CORS設定（本番URLのみ）
ALLOWED_ORIGINS=https://your-app.vercel.app

# サーバー設定
ENV=production
PORT=8080
```

**重要:** DATABASE_DSNは必ず**Pooled Connection**（`-pooler`を含むURL）を使用してください。

### Vercel環境変数

```bash
# RailwayのバックエンドURL
NEXT_PUBLIC_API_BASE_URL=https://your-railway-app.railway.app

# Firebase設定
NEXT_PUBLIC_FIREBASE_API_KEY=your-api-key
NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
NEXT_PUBLIC_FIREBASE_PROJECT_ID=your-project-id
NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your-project.appspot.com
NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=123456789
NEXT_PUBLIC_FIREBASE_APP_ID=1:123456789:web:abc123
```

### Firebase Console

**Authorized domains に追加:**
- `your-app.vercel.app`（本番ドメイン）
- `localhost`（開発環境）

---

## デプロイ手順

1. **Railway**: 
   - GitHubリポジトリを連携
   - 環境変数を設定
   - 自動デプロイが実行される

2. **Vercel**:
   - 環境変数を設定
   - `main`ブランチにマージで自動デプロイ

---

## 動作確認

### ローカルでのDockerビルド確認
```bash
cd backend
docker build -t money-buddy-backend .

# ローカルで実行確認
docker run -p 8080:8080 \
  -e DATABASE_DSN="..." \
  -e FIREBASE_CREDENTIALS_JSON="..." \
  -e ALLOWED_ORIGINS="http://localhost:3000" \
  money-buddy-backend
```

### デプロイ後の確認
```bash
# ヘルスチェック
curl https://your-railway-app.railway.app/health

# レスポンス: {"status":"ok"}
```

### ログ確認
Railwayのログで以下が表示されることを確認：
```
Database connection established and tested successfully
Starting server on port 8080
```

---

## トラブルシューティング

### CORS エラーが出る場合
- Railwayの`ALLOWED_ORIGINS`がVercelの本番URLと完全一致しているか確認
- `https://` を含めているか確認
- 末尾の `/` がないか確認

### データベース接続エラー
- DATABASE_DSNに**Pooled Connection**（`-pooler`）を使用しているか確認
- Neonのコンピュートが起動しているか確認（初回は数秒かかる）

### Firebase認証エラー
- Firebase Consoleの Authorized domains にVercelのURLを追加
- FIREBASE_CREDENTIALS_JSON が正しいJSON形式か確認

---

## 制限事項

### プレビューデプロイ
現在のCORS設定は本番URLのみを許可しているため、Vercelのプレビューデプロイ（Pull Request用の一時URL）では認証が動作しません。

**回避策:**
- 開発中は `localhost` で確認
- 本番デプロイのみVercelで確認

**将来の改善案:**
- カスタムドメインを設定し、プレビュー用サブドメインを固定
- または、ワイルドカード対応（セキュリティリスクあり）

---

## 関連Issue
- Closes: #84 
