### PR TITLE
feat: 支出一覧の月指定フィルタリングとカレンダービューの追加

### DIFF
--- a/backend/db/generated/expenses.sql.go
+++ b/backend/db/generated/expenses.sql.go
@@ -203,6 +203,69 @@ func (q *Queries) ListExpenses(ctx context.Context, userID string) ([]ListExpens
 	return items, nil
 }
 
+const listExpensesByMonth = `-- name: ListExpensesByMonth :many
+SELECT
+  e.id,
+  e.amount,
+  e.memo,
+  e.spent_at,
+  e.status,
+  c.id AS category_id,
+  c.name AS category_name
+FROM expenses e
+JOIN categories c ON e.category_id = c.id
+WHERE e.user_id = $1
+  AND DATE_TRUNC('month', e.spent_at) = DATE_TRUNC('month', MAKE_DATE($2::int4, $3::int4, 1))
+ORDER BY e.spent_at DESC
+`
+
+type ListExpensesByMonthParams struct {
+	UserID string
+	Year   int32
+	Month  int32
+}
+
+type ListExpensesByMonthRow struct {
+	ID           int32
+	Amount       int32
+	Memo         sql.NullString
+	SpentAt      time.Time
+	Status       string
+	CategoryID   int32
+	CategoryName string
+}
+
+func (q *Queries) ListExpensesByMonth(ctx context.Context, arg ListExpensesByMonthParams) ([]ListExpensesByMonthRow, error) {
+	rows, err := q.db.QueryContext(ctx, listExpensesByMonth, arg.UserID, arg.Year, arg.Month)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListExpensesByMonthRow
+	for rows.Next() {
+		var i ListExpensesByMonthRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Amount,
+			&i.Memo,
+			&i.SpentAt,
+			&i.Status,
+			&i.CategoryID,
+			&i.CategoryName,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const updateExpense = `-- name: UpdateExpense :exec
 UPDATE expenses
 SET

--- a/backend/db/generated/expenses.sql.go
+++ b/backend/db/generated/expenses.sql.go
@@ -215,7 +215,8 @@ SELECT
 FROM expenses e
 JOIN categories c ON e.category_id = c.id
 WHERE e.user_id = $1
-  AND DATE_TRUNC('month', e.spent_at) = DATE_TRUNC('month', MAKE_DATE($2::int4, $3::int4, 1))
+  AND e.spent_at >= MAKE_DATE($2::int4, $3::int4, 1)
+  AND e.spent_at < MAKE_DATE($2::int4, $3::int4, 1) + INTERVAL '1 month'
 ORDER BY e.spent_at DESC
 `
 

--- a/backend/db/query/expenses.sql
+++ b/backend/db/query/expenses.sql
@@ -79,7 +79,8 @@ SELECT
 FROM expenses e
 JOIN categories c ON e.category_id = c.id
 WHERE e.user_id = $1
-  AND DATE_TRUNC('month', e.spent_at) = DATE_TRUNC('month', MAKE_DATE(sqlc.arg(year)::int4, sqlc.arg(month)::int4, 1))
+  AND e.spent_at >= MAKE_DATE(sqlc.arg(year)::int4, sqlc.arg(month)::int4, 1)
+  AND e.spent_at < MAKE_DATE(sqlc.arg(year)::int4, sqlc.arg(month)::int4, 1) + INTERVAL '1 month'
 ORDER BY e.spent_at DESC;
 
 -- name: DeleteExpense :exec

--- a/backend/db/query/expenses.sql
+++ b/backend/db/query/expenses.sql
@@ -67,6 +67,21 @@ SET
   updated_at = now()
 WHERE id = $1 AND user_id = $3;
 
+-- name: ListExpensesByMonth :many
+SELECT
+  e.id,
+  e.amount,
+  e.memo,
+  e.spent_at,
+  e.status,
+  c.id AS category_id,
+  c.name AS category_name
+FROM expenses e
+JOIN categories c ON e.category_id = c.id
+WHERE e.user_id = $1
+  AND DATE_TRUNC('month', e.spent_at) = DATE_TRUNC('month', MAKE_DATE(sqlc.arg(year)::int4, sqlc.arg(month)::int4, 1))
+ORDER BY e.spent_at DESC;
+
 -- name: DeleteExpense :exec
 DELETE FROM expenses
 WHERE id = $1 AND user_id = $2;

--- a/backend/infra/repository/expense_repository_sqlc.go
+++ b/backend/infra/repository/expense_repository_sqlc.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	db "money-buddy-backend/db/generated"
+	"money-buddy-backend/infra/transaction"
 	"money-buddy-backend/internal/domain"
 	"money-buddy-backend/internal/usecase"
 )
@@ -17,6 +18,13 @@ type expenseRepositorySQLC struct {
 
 func NewExpenseRepositorySQLC(q *db.Queries) *expenseRepositorySQLC {
 	return &expenseRepositorySQLC{q: q}
+}
+
+func (r *expenseRepositorySQLC) queries(ctx context.Context) *db.Queries {
+	if tx, ok := transaction.TxFromContext(ctx); ok {
+		return r.q.WithTx(tx)
+	}
+	return r.q
 }
 
 func (r *expenseRepositorySQLC) CreateExpense(userID string, input usecase.CreateExpenseInput) (domain.Expense, error) {
@@ -71,8 +79,8 @@ func (r *expenseRepositorySQLC) FindAll(userID string) ([]domain.Expense, error)
 	return out, nil
 }
 
-func (r *expenseRepositorySQLC) FindByMonth(userID string, year, month int) ([]domain.Expense, error) {
-	items, err := r.q.ListExpensesByMonth(context.Background(), db.ListExpensesByMonthParams{
+func (r *expenseRepositorySQLC) FindByMonth(ctx context.Context, userID string, year, month int) ([]domain.Expense, error) {
+	items, err := r.queries(ctx).ListExpensesByMonth(ctx, db.ListExpensesByMonthParams{
 		UserID: userID,
 		Year:   int32(year),
 		Month:  int32(month),

--- a/backend/infra/repository/expense_repository_sqlc.go
+++ b/backend/infra/repository/expense_repository_sqlc.go
@@ -71,6 +71,38 @@ func (r *expenseRepositorySQLC) FindAll(userID string) ([]domain.Expense, error)
 	return out, nil
 }
 
+func (r *expenseRepositorySQLC) FindByMonth(userID string, year, month int) ([]domain.Expense, error) {
+	items, err := r.q.ListExpensesByMonth(context.Background(), db.ListExpensesByMonthParams{
+		UserID: userID,
+		Year:   int32(year),
+		Month:  int32(month),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var out []domain.Expense
+	for _, it := range items {
+		out = append(out, dbListExpensesByMonthRowToModel(it))
+	}
+	return out, nil
+}
+
+func dbListExpensesByMonthRowToModel(e db.ListExpensesByMonthRow) domain.Expense {
+	memo := ""
+	if e.Memo.Valid {
+		memo = e.Memo.String
+	}
+	return domain.Expense{
+		ID:       int(e.ID),
+		Amount:   int(e.Amount),
+		Memo:     memo,
+		SpentAt:  e.SpentAt.Format(time.RFC3339),
+		Status:   e.Status,
+		Category: domain.Category{ID: int(e.CategoryID), Name: e.CategoryName},
+	}
+}
+
 func dbExpenseToModel(e db.GetExpenseWithCategoryByIDRow) domain.Expense {
 	memo := ""
 	if e.Memo.Valid {

--- a/backend/internal/handlers/expense_dashboard_test.go
+++ b/backend/internal/handlers/expense_dashboard_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"money-buddy-backend/internal/domain"
@@ -141,12 +142,12 @@ func TestCreateExpenseHandler_InternalError(t *testing.T) {
 // --- List Expenses ---
 
 type mockListExpensesUC struct {
-	fn func(userID string) ([]domain.Expense, error)
+	fn func(userID string, filter usecase.MonthFilter) ([]domain.Expense, error)
 }
 
-func (m *mockListExpensesUC) Execute(userID string) ([]domain.Expense, error) {
+func (m *mockListExpensesUC) Execute(userID string, filter usecase.MonthFilter) ([]domain.Expense, error) {
 	if m.fn != nil {
-		return m.fn(userID)
+		return m.fn(userID, filter)
 	}
 	return nil, nil
 }
@@ -155,7 +156,7 @@ func TestListExpensesHandler_Success(t *testing.T) {
 	router := newRouterWithUserID("test-user")
 
 	uc := &mockListExpensesUC{
-		fn: func(userID string) ([]domain.Expense, error) {
+		fn: func(userID string, filter usecase.MonthFilter) ([]domain.Expense, error) {
 			return []domain.Expense{{ID: 1, Amount: 500}, {ID: 2, Amount: 1000}}, nil
 		},
 	}
@@ -170,6 +171,77 @@ func TestListExpensesHandler_Success(t *testing.T) {
 	var resp map[string][]domain.Expense
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Len(t, resp["expenses"], 2)
+}
+
+func TestListExpensesHandler_WithMonthFilter(t *testing.T) {
+	router := newRouterWithUserID("test-user")
+
+	var gotFilter usecase.MonthFilter
+	uc := &mockListExpensesUC{
+		fn: func(userID string, filter usecase.MonthFilter) ([]domain.Expense, error) {
+			gotFilter = filter
+			return []domain.Expense{{ID: 1, Amount: 500}}, nil
+		},
+	}
+	router.GET("/expenses", NewListExpensesHandler(uc).Handle)
+
+	req := httptest.NewRequest(http.MethodGet, "/expenses?year=2025&month=3", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 2025, gotFilter.Year)
+	assert.Equal(t, 3, gotFilter.Month)
+}
+
+func TestListExpensesHandler_InvalidYear(t *testing.T) {
+	router := newRouterWithUserID("test-user")
+	router.GET("/expenses", NewListExpensesHandler(&mockListExpensesUC{}).Handle)
+
+	cases := []struct{ query string }{
+		{"/expenses?year=abc&month=4"},
+		{"/expenses?year=0&month=4"},
+		{"/expenses?year=-1&month=4"},
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(http.MethodGet, tc.query, nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code, "query: %s", tc.query)
+	}
+}
+
+func TestListExpensesHandler_InvalidMonth(t *testing.T) {
+	router := newRouterWithUserID("test-user")
+	router.GET("/expenses", NewListExpensesHandler(&mockListExpensesUC{}).Handle)
+
+	cases := []struct{ query string }{
+		{"/expenses?year=2025&month=0"},
+		{"/expenses?year=2025&month=13"},
+		{"/expenses?year=2025&month=abc"},
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(http.MethodGet, tc.query, nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code, "query: %s", tc.query)
+	}
+}
+
+func TestListExpensesHandler_PartialFilter(t *testing.T) {
+	router := newRouterWithUserID("test-user")
+	router.GET("/expenses", NewListExpensesHandler(&mockListExpensesUC{}).Handle)
+
+	cases := []struct{ query string }{
+		{"/expenses?year=2025"},
+		{"/expenses?month=4"},
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(http.MethodGet, tc.query, nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code, "query: %s", tc.query)
+	}
 }
 
 // --- Delete Expense ---

--- a/backend/internal/handlers/expense_dashboard_test.go
+++ b/backend/internal/handlers/expense_dashboard_test.go
@@ -145,7 +145,7 @@ type mockListExpensesUC struct {
 	fn func(userID string, filter usecase.MonthFilter) ([]domain.Expense, error)
 }
 
-func (m *mockListExpensesUC) Execute(userID string, filter usecase.MonthFilter) ([]domain.Expense, error) {
+func (m *mockListExpensesUC) Execute(ctx context.Context, userID string, filter usecase.MonthFilter) ([]domain.Expense, error) {
 	if m.fn != nil {
 		return m.fn(userID, filter)
 	}

--- a/backend/internal/handlers/list_expenses.go
+++ b/backend/internal/handlers/list_expenses.go
@@ -2,15 +2,17 @@ package handlers
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 
 	"money-buddy-backend/internal/domain"
 	"money-buddy-backend/internal/middleware"
+	"money-buddy-backend/internal/usecase"
 )
 
 type listExpensesUseCase interface {
-	Execute(userID string) ([]domain.Expense, error)
+	Execute(userID string, filter usecase.MonthFilter) ([]domain.Expense, error)
 }
 
 type ListExpensesHandler struct {
@@ -28,7 +30,32 @@ func (h *ListExpensesHandler) Handle(c *gin.Context) {
 		return
 	}
 
-	expenses, err := h.uc.Execute(userID)
+	var filter usecase.MonthFilter
+
+	if yearStr := c.Query("year"); yearStr != "" {
+		year, err := strconv.Atoi(yearStr)
+		if err != nil || year < 1 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "yearは正の整数で指定してください"})
+			return
+		}
+		filter.Year = year
+	}
+
+	if monthStr := c.Query("month"); monthStr != "" {
+		month, err := strconv.Atoi(monthStr)
+		if err != nil || month < 1 || month > 12 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "monthは1から12の整数で指定してください"})
+			return
+		}
+		filter.Month = month
+	}
+
+	if (filter.Year == 0) != (filter.Month == 0) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "yearとmonthは両方指定するか、両方省略してください"})
+		return
+	}
+
+	expenses, err := h.uc.Execute(userID, filter)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "支出の取得に失敗しました"})
 		return

--- a/backend/internal/handlers/list_expenses.go
+++ b/backend/internal/handlers/list_expenses.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 
@@ -12,7 +13,7 @@ import (
 )
 
 type listExpensesUseCase interface {
-	Execute(userID string, filter usecase.MonthFilter) ([]domain.Expense, error)
+	Execute(ctx context.Context, userID string, filter usecase.MonthFilter) ([]domain.Expense, error)
 }
 
 type ListExpensesHandler struct {
@@ -55,7 +56,7 @@ func (h *ListExpensesHandler) Handle(c *gin.Context) {
 		return
 	}
 
-	expenses, err := h.uc.Execute(userID, filter)
+	expenses, err := h.uc.Execute(c.Request.Context(), userID, filter)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "支出の取得に失敗しました"})
 		return

--- a/backend/internal/usecase/expense_test.go
+++ b/backend/internal/usecase/expense_test.go
@@ -488,7 +488,7 @@ type mockListExpenseRepo struct {
 	fn func(userID string, year, month int) ([]domain.Expense, error)
 }
 
-func (m *mockListExpenseRepo) FindByMonth(userID string, year, month int) ([]domain.Expense, error) {
+func (m *mockListExpenseRepo) FindByMonth(ctx context.Context, userID string, year, month int) ([]domain.Expense, error) {
 	if m.fn != nil {
 		return m.fn(userID, year, month)
 	}
@@ -510,7 +510,7 @@ func TestListExpenseUseCase_DefaultsToCurrentMonth(t *testing.T) {
 	fixed := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
 	uc.nowFn = func() time.Time { return fixed }
 
-	_, err := uc.Execute("user1", MonthFilter{})
+	_, err := uc.Execute(context.Background(), "user1", MonthFilter{})
 	require.NoError(t, err)
 	assert.Equal(t, 2024, gotYear)
 	assert.Equal(t, 6, gotMonth)
@@ -529,7 +529,7 @@ func TestListExpenseUseCase_WithMonthFilter(t *testing.T) {
 	}
 	uc := NewListExpensesUseCase(repo)
 
-	result, err := uc.Execute("user1", MonthFilter{Year: 2024, Month: 11})
+	result, err := uc.Execute(context.Background(), "user1", MonthFilter{Year: 2024, Month: 11})
 	require.NoError(t, err)
 	assert.Equal(t, 2024, gotYear)
 	assert.Equal(t, 11, gotMonth)
@@ -550,7 +550,7 @@ func TestListExpenseUseCase_PartialZeroDoesNotOverride(t *testing.T) {
 	uc := NewListExpensesUseCase(repo)
 
 	// year が指定されているが month=0 の場合、year を上書きしない
-	_, err := uc.Execute("user1", MonthFilter{Year: 2024, Month: 0})
+	_, err := uc.Execute(context.Background(), "user1", MonthFilter{Year: 2024, Month: 0})
 	require.NoError(t, err)
 	assert.Equal(t, 2024, gotYear)
 	assert.Equal(t, 0, gotMonth)
@@ -566,6 +566,6 @@ func TestListExpenseUseCase_RepoError(t *testing.T) {
 	}
 	uc := NewListExpensesUseCase(repo)
 
-	_, err := uc.Execute("user1", MonthFilter{Year: 2024, Month: 1})
+	_, err := uc.Execute(context.Background(), "user1", MonthFilter{Year: 2024, Month: 1})
 	assert.Error(t, err)
 }

--- a/backend/internal/usecase/expense_test.go
+++ b/backend/internal/usecase/expense_test.go
@@ -535,6 +535,26 @@ func TestListExpenseUseCase_WithMonthFilter(t *testing.T) {
 	assert.Len(t, result, 1)
 }
 
+func TestListExpenseUseCase_PartialZeroDoesNotOverride(t *testing.T) {
+	t.Parallel()
+
+	var gotYear, gotMonth int
+	repo := &mockListExpenseRepo{
+		fn: func(userID string, year, month int) ([]domain.Expense, error) {
+			gotYear = year
+			gotMonth = month
+			return nil, nil
+		},
+	}
+	uc := NewListExpensesUseCase(repo)
+
+	// year が指定されているが month=0 の場合、year を上書きしない
+	_, err := uc.Execute("user1", MonthFilter{Year: 2024, Month: 0})
+	require.NoError(t, err)
+	assert.Equal(t, 2024, gotYear)
+	assert.Equal(t, 0, gotMonth)
+}
+
 func TestListExpenseUseCase_RepoError(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/usecase/expense_test.go
+++ b/backend/internal/usecase/expense_test.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"money-buddy-backend/internal/domain"
 )
@@ -478,4 +480,71 @@ func TestUpdateExpense_NotFound(t *testing.T) {
 	_, err := uc.Execute("test-user", input)
 	assert.ErrorIs(t, err, ErrInvalidStatusTransition)
 	assert.False(t, repo.called)
+}
+
+// --- mocks for list expenses ---
+
+type mockListExpenseRepo struct {
+	fn func(userID string, year, month int) ([]domain.Expense, error)
+}
+
+func (m *mockListExpenseRepo) FindByMonth(userID string, year, month int) ([]domain.Expense, error) {
+	if m.fn != nil {
+		return m.fn(userID, year, month)
+	}
+	return nil, nil
+}
+
+func TestListExpenseUseCase_DefaultsToCurrentMonth(t *testing.T) {
+	t.Parallel()
+
+	var gotYear, gotMonth int
+	repo := &mockListExpenseRepo{
+		fn: func(userID string, year, month int) ([]domain.Expense, error) {
+			gotYear = year
+			gotMonth = month
+			return nil, nil
+		},
+	}
+	uc := NewListExpensesUseCase(repo)
+
+	now := time.Now()
+	_, err := uc.Execute("user1", MonthFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, now.Year(), gotYear)
+	assert.Equal(t, int(now.Month()), gotMonth)
+}
+
+func TestListExpenseUseCase_WithMonthFilter(t *testing.T) {
+	t.Parallel()
+
+	var gotYear, gotMonth int
+	repo := &mockListExpenseRepo{
+		fn: func(userID string, year, month int) ([]domain.Expense, error) {
+			gotYear = year
+			gotMonth = month
+			return []domain.Expense{{ID: 1}}, nil
+		},
+	}
+	uc := NewListExpensesUseCase(repo)
+
+	result, err := uc.Execute("user1", MonthFilter{Year: 2024, Month: 11})
+	require.NoError(t, err)
+	assert.Equal(t, 2024, gotYear)
+	assert.Equal(t, 11, gotMonth)
+	assert.Len(t, result, 1)
+}
+
+func TestListExpenseUseCase_RepoError(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockListExpenseRepo{
+		fn: func(userID string, year, month int) ([]domain.Expense, error) {
+			return nil, errors.New("db error")
+		},
+	}
+	uc := NewListExpensesUseCase(repo)
+
+	_, err := uc.Execute("user1", MonthFilter{Year: 2024, Month: 1})
+	assert.Error(t, err)
 }

--- a/backend/internal/usecase/expense_test.go
+++ b/backend/internal/usecase/expense_test.go
@@ -507,12 +507,13 @@ func TestListExpenseUseCase_DefaultsToCurrentMonth(t *testing.T) {
 		},
 	}
 	uc := NewListExpensesUseCase(repo)
+	fixed := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	uc.nowFn = func() time.Time { return fixed }
 
-	now := time.Now()
 	_, err := uc.Execute("user1", MonthFilter{})
 	require.NoError(t, err)
-	assert.Equal(t, now.Year(), gotYear)
-	assert.Equal(t, int(now.Month()), gotMonth)
+	assert.Equal(t, 2024, gotYear)
+	assert.Equal(t, 6, gotMonth)
 }
 
 func TestListExpenseUseCase_WithMonthFilter(t *testing.T) {

--- a/backend/internal/usecase/list_expenses.go
+++ b/backend/internal/usecase/list_expenses.go
@@ -28,7 +28,7 @@ func NewListExpensesUseCase(repo listExpenseRepository) *ListExpensesUseCase {
 // Execute は支出一覧取得ユースケースを実行します。year/month が 0 の場合は当月を使用します。
 func (uc *ListExpensesUseCase) Execute(userID string, filter MonthFilter) ([]domain.Expense, error) {
 	year, month := filter.Year, filter.Month
-	if year == 0 || month == 0 {
+	if year == 0 && month == 0 {
 		now := time.Now()
 		year = now.Year()
 		month = int(now.Month())

--- a/backend/internal/usecase/list_expenses.go
+++ b/backend/internal/usecase/list_expenses.go
@@ -17,19 +17,20 @@ type listExpenseRepository interface {
 
 // ListExpensesUseCase は支出一覧取得ユースケースです。
 type ListExpensesUseCase struct {
-	repo listExpenseRepository
+	repo  listExpenseRepository
+	nowFn func() time.Time
 }
 
 // NewListExpensesUseCase は ListExpensesUseCase の新しいインスタンスを生成します。
 func NewListExpensesUseCase(repo listExpenseRepository) *ListExpensesUseCase {
-	return &ListExpensesUseCase{repo: repo}
+	return &ListExpensesUseCase{repo: repo, nowFn: time.Now}
 }
 
-// Execute は支出一覧取得ユースケースを実行します。year/month が 0 の場合は当月を使用します。
+// Execute は支出一覧取得ユースケースを実行します。year/month が両方 0 の場合は当月を使用します。
 func (uc *ListExpensesUseCase) Execute(userID string, filter MonthFilter) ([]domain.Expense, error) {
 	year, month := filter.Year, filter.Month
 	if year == 0 && month == 0 {
-		now := time.Now()
+		now := uc.nowFn()
 		year = now.Year()
 		month = int(now.Month())
 	}

--- a/backend/internal/usecase/list_expenses.go
+++ b/backend/internal/usecase/list_expenses.go
@@ -1,9 +1,18 @@
 package usecase
 
-import "money-buddy-backend/internal/domain"
+import (
+	"time"
+
+	"money-buddy-backend/internal/domain"
+)
+
+type MonthFilter struct {
+	Year  int
+	Month int
+}
 
 type listExpenseRepository interface {
-	FindAll(userID string) ([]domain.Expense, error)
+	FindByMonth(userID string, year, month int) ([]domain.Expense, error)
 }
 
 // ListExpensesUseCase は支出一覧取得ユースケースです。
@@ -16,7 +25,13 @@ func NewListExpensesUseCase(repo listExpenseRepository) *ListExpensesUseCase {
 	return &ListExpensesUseCase{repo: repo}
 }
 
-// Execute は支出一覧取得ユースケースを実行します。
-func (uc *ListExpensesUseCase) Execute(userID string) ([]domain.Expense, error) {
-	return uc.repo.FindAll(userID)
+// Execute は支出一覧取得ユースケースを実行します。year/month が 0 の場合は当月を使用します。
+func (uc *ListExpensesUseCase) Execute(userID string, filter MonthFilter) ([]domain.Expense, error) {
+	year, month := filter.Year, filter.Month
+	if year == 0 || month == 0 {
+		now := time.Now()
+		year = now.Year()
+		month = int(now.Month())
+	}
+	return uc.repo.FindByMonth(userID, year, month)
 }

--- a/backend/internal/usecase/list_expenses.go
+++ b/backend/internal/usecase/list_expenses.go
@@ -1,6 +1,7 @@
 package usecase
 
 import (
+	"context"
 	"time"
 
 	"money-buddy-backend/internal/domain"
@@ -12,7 +13,7 @@ type MonthFilter struct {
 }
 
 type listExpenseRepository interface {
-	FindByMonth(userID string, year, month int) ([]domain.Expense, error)
+	FindByMonth(ctx context.Context, userID string, year, month int) ([]domain.Expense, error)
 }
 
 // ListExpensesUseCase は支出一覧取得ユースケースです。
@@ -27,12 +28,12 @@ func NewListExpensesUseCase(repo listExpenseRepository) *ListExpensesUseCase {
 }
 
 // Execute は支出一覧取得ユースケースを実行します。year/month が両方 0 の場合は当月を使用します。
-func (uc *ListExpensesUseCase) Execute(userID string, filter MonthFilter) ([]domain.Expense, error) {
+func (uc *ListExpensesUseCase) Execute(ctx context.Context, userID string, filter MonthFilter) ([]domain.Expense, error) {
 	year, month := filter.Year, filter.Month
 	if year == 0 && month == 0 {
 		now := uc.nowFn()
 		year = now.Year()
 		month = int(now.Month())
 	}
-	return uc.repo.FindByMonth(userID, year, month)
+	return uc.repo.FindByMonth(ctx, userID, year, month)
 }

--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -51,7 +51,22 @@ paths:
       tags:
         - "expenses"
       summary: "List expenses"
-      parameters: []
+      parameters:
+        - name: year
+          in: query
+          required: false
+          description: "絞り込む年（例: 2026）。monthと共に指定。省略時は当年。"
+          schema:
+            type: integer
+            minimum: 1
+        - name: month
+          in: query
+          required: false
+          description: "絞り込む月（1〜12）。yearと共に指定。省略時は当月。"
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 12
       responses:
         "200":
           description: "List of expenses"

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -160,9 +160,9 @@ export default function Home() {
         <div className="space-y-2">
           <div className="flex items-center justify-between gap-2 flex-wrap">
             <div className="flex items-center gap-2">
-              <Button variant="ghost" size="sm" onClick={() => navigateMonth('prev')}>‹</Button>
+              <Button variant="ghost" size="sm" aria-label="前月へ" onClick={() => navigateMonth('prev')}>‹</Button>
               <span className="text-base font-semibold text-foreground min-w-[120px] text-center">{monthLabel}</span>
-              <Button variant="ghost" size="sm" onClick={() => navigateMonth('next')}>›</Button>
+              <Button variant="ghost" size="sm" aria-label="翌月へ" onClick={() => navigateMonth('next')}>›</Button>
             </div>
             <div className="flex gap-1">
               <Button

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,6 +6,8 @@ import { useUser } from '@/hooks/useUser'
 import { useDashboard } from '@/hooks/useDashboard'
 import { ExpenseForm } from '@/components/ExpenseForm'
 import { ExpenseList } from '@/components/ExpenseList'
+import { ExpenseCalendar } from '@/components/ExpenseCalendar'
+import { Button } from '@/components/ui/Button'
 import { InitialSetupForm } from '@/components/InitialSetupForm'
 import { Dashboard } from '@/components/Dashboard'
 import { Container } from '@/components/Layout/Container'
@@ -15,11 +17,15 @@ import { Expense, UpdateExpenseInput } from '@/lib/types/expense'
 
 export default function Home() {
   const { user, needsSetup, isLoading: userLoading, error: userError, refetchUser } = useUser()
-  const { expenses, createExpense, updateExpense, deleteExpense, isSubmitting, isLoading, error } = useExpenses()
+  const { expenses, selectedMonth, navigateMonth, createExpense, updateExpense, deleteExpense, isSubmitting, isLoading, error } = useExpenses()
   const { dashboard, isLoading: dashboardLoading, error: dashboardError, refetch: refetchDashboard } = useDashboard({ enabled: !needsSetup })
   const [setupSubmitting, setSetupSubmitting] = useState(false)
   const [setupError, setSetupError] = useState<string | null>(null)
   const [editingExpense, setEditingExpense] = useState<Expense | null>(null)
+  const [viewMode, setViewMode] = useState<'list' | 'calendar'>('list')
+
+  const MONTH_NAMES = ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月']
+  const monthLabel = `${selectedMonth.year}年${MONTH_NAMES[selectedMonth.month - 1]}`
 
   const handleSetupSubmit = async (input: InitialSetupRequest) => {
     setSetupSubmitting(true)
@@ -152,8 +158,34 @@ export default function Home() {
         {error && <p className="text-danger">{error}</p>}
 
         <div className="space-y-2">
-          <h3 className="text-lg font-semibold text-foreground">支出一覧</h3>
-          <ExpenseList expenses={expenses} onEdit={handleEdit} onDelete={handleDelete} isSubmitting={isSubmitting} />
+          <div className="flex items-center justify-between gap-2 flex-wrap">
+            <div className="flex items-center gap-2">
+              <Button variant="ghost" size="sm" onClick={() => navigateMonth('prev')}>‹</Button>
+              <span className="text-base font-semibold text-foreground min-w-[120px] text-center">{monthLabel}</span>
+              <Button variant="ghost" size="sm" onClick={() => navigateMonth('next')}>›</Button>
+            </div>
+            <div className="flex gap-1">
+              <Button
+                variant={viewMode === 'list' ? 'primary' : 'secondary'}
+                size="sm"
+                onClick={() => setViewMode('list')}
+              >
+                リスト
+              </Button>
+              <Button
+                variant={viewMode === 'calendar' ? 'primary' : 'secondary'}
+                size="sm"
+                onClick={() => setViewMode('calendar')}
+              >
+                カレンダー
+              </Button>
+            </div>
+          </div>
+          {viewMode === 'list' ? (
+            <ExpenseList expenses={expenses} onEdit={handleEdit} onDelete={handleDelete} isSubmitting={isSubmitting} />
+          ) : (
+            <ExpenseCalendar expenses={expenses} year={selectedMonth.year} month={selectedMonth.month} />
+          )}
         </div>
       </section>
     </Container>

--- a/frontend/src/components/ExpenseCalendar.tsx
+++ b/frontend/src/components/ExpenseCalendar.tsx
@@ -1,0 +1,81 @@
+import { Expense } from "@/lib/types/expense";
+
+type Props = {
+  expenses: Expense[];
+  year: number;
+  month: number;
+};
+
+const WEEKDAY_LABELS = ['日', '月', '火', '水', '木', '金', '土'];
+
+function getExpensesForDay(expenses: Expense[], year: number, month: number, day: number): Expense[] {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const prefix = `${year}-${pad(month)}-${pad(day)}`;
+  return expenses.filter((e) => e.spent_at.startsWith(prefix));
+}
+
+export function ExpenseCalendar({ expenses, year, month }: Props) {
+  const firstDay = new Date(year, month - 1, 1).getDay();
+  const daysInMonth = new Date(year, month, 0).getDate();
+  const today = new Date();
+
+  const cells: (number | null)[] = [
+    ...Array(firstDay).fill(null),
+    ...Array.from({ length: daysInMonth }, (_, i) => i + 1),
+  ];
+  while (cells.length % 7 !== 0) cells.push(null);
+
+  return (
+    <div className="bg-card border border-border rounded-lg shadow-sm p-4">
+      <div className="grid grid-cols-7 mb-2">
+        {WEEKDAY_LABELS.map((label) => (
+          <div key={label} className="text-center text-xs font-semibold text-muted-foreground py-1">
+            {label}
+          </div>
+        ))}
+      </div>
+      <div className="grid grid-cols-7 gap-px bg-border">
+        {cells.map((day, idx) => {
+          if (!day) return <div key={idx} className="bg-card min-h-[80px]" />;
+
+          const dayExpenses = getExpensesForDay(expenses, year, month, day);
+          const totalAmount = dayExpenses.reduce((sum, e) => sum + e.amount, 0);
+          const isToday =
+            today.getFullYear() === year &&
+            today.getMonth() + 1 === month &&
+            today.getDate() === day;
+
+          return (
+            <div key={idx} className="bg-card min-h-[80px] p-1">
+              <div className={`text-xs font-medium mb-1 ${isToday ? 'text-primary font-bold' : 'text-foreground'}`}>
+                {day}
+              </div>
+              {dayExpenses.length > 0 && (
+                <div className="space-y-0.5">
+                  <div className="text-xs font-semibold text-foreground">
+                    ¥{totalAmount.toLocaleString()}
+                  </div>
+                  {dayExpenses.slice(0, 2).map((e) => (
+                    <div
+                      key={e.id}
+                      className={`text-xs truncate px-1 rounded ${
+                        e.status === 'confirmed'
+                          ? 'bg-success text-success-foreground'
+                          : 'bg-warning text-warning-foreground'
+                      }`}
+                    >
+                      {e.category.name}
+                    </div>
+                  ))}
+                  {dayExpenses.length > 2 && (
+                    <div className="text-xs text-muted-foreground">+{dayExpenses.length - 2}件</div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useExpenses.ts
+++ b/frontend/src/hooks/useExpenses.ts
@@ -2,7 +2,15 @@ import { useEffect, useState } from "react";
 import { createExpense, getExpenses, updateExpense, deleteExpense } from "@/lib/api/expenses";
 import { CreateExpenseInput, UpdateExpenseInput, Expense } from "@/lib/types/expense";
 
+type SelectedMonth = { year: number; month: number };
+
+function currentMonth(): SelectedMonth {
+    const now = new Date();
+    return { year: now.getFullYear(), month: now.getMonth() + 1 };
+}
+
 export function useExpenses() {
+    const [selectedMonth, setSelectedMonth] = useState<SelectedMonth>(currentMonth);
     const [expenses, setExpenses] = useState<Expense[]>([]);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
@@ -15,7 +23,7 @@ export function useExpenses() {
             setError(null);
 
             try {
-                const data = await getExpenses();
+                const data = await getExpenses(selectedMonth);
                 setExpenses(data.expenses);
             } catch (err) {
                 setError(err instanceof Error ? err.message : 'エラーが発生しました');
@@ -25,7 +33,16 @@ export function useExpenses() {
         }
 
         fetchExpenses();
-    }, []);
+    }, [selectedMonth.year, selectedMonth.month]);
+
+    const navigateMonth = (direction: 'prev' | 'next') => {
+        setSelectedMonth(({ year, month }) => {
+            if (direction === 'prev') {
+                return month === 1 ? { year: year - 1, month: 12 } : { year, month: month - 1 };
+            }
+            return month === 12 ? { year: year + 1, month: 1 } : { year, month: month + 1 };
+        });
+    };
 
     // POST
     const handleCreateExpense = async (input: CreateExpenseInput): Promise<boolean> => {
@@ -82,6 +99,8 @@ export function useExpenses() {
 
     return {
         expenses,
+        selectedMonth,
+        navigateMonth,
         isLoading,
         isSubmitting,
         error,

--- a/frontend/src/lib/api/expenses.ts
+++ b/frontend/src/lib/api/expenses.ts
@@ -27,9 +27,14 @@ export async function createExpense(
 }
 
 
-export async function getExpenses(): Promise<GetExpensesResponse> {
+export async function getExpenses(params?: { year: number; month: number }): Promise<GetExpensesResponse> {
   const headers = await getAuthHeaders();
-  const res = await fetch(`${API_BASE_URL}/expenses`, {
+  const url = new URL(`${API_BASE_URL}/expenses`);
+  if (params) {
+    url.searchParams.set('year', String(params.year));
+    url.searchParams.set('month', String(params.month));
+  }
+  const res = await fetch(url.toString(), {
     method: "GET",
     headers,
   });


### PR DESCRIPTION
## Summary

- `GET /expenses` に `?year` / `?month` クエリパラメータを追加し、月ごとの支出取得を可能にした（省略時は当月）
- フロントエンドに月ナビゲーション（‹ 前月 / 翌月 ›）とリスト/カレンダービューの切り替えを追加した

## Changes

### Backend
- `ListExpensesByMonth` SQL クエリ追加（`MAKE_DATE + DATE_TRUNC` で月フィルタ）
- sqlc 再生成（`Year`/`Month` 名前付きパラメータ）
- `FindByMonth` メソッドをリポジトリに追加
- `ListExpensesUseCase` に `MonthFilter` 型を導入、省略時は当月にデフォルト
- ハンドラで `?year` / `?month` クエリパラメータを解析・バリデーション
- OpenAPI spec に新パラメータを文書化

### Frontend
- `getExpenses(params?)` に年月パラメータを追加
- `useExpenses` フックに `selectedMonth` 状態と `navigateMonth('prev'|'next')` を追加
- `ExpenseCalendar` コンポーネント新規作成（7列グリッド、日ごとの合計金額・カテゴリバッジ表示、今日ハイライト）
- ホームページに月ナビゲーションバーとリスト/カレンダー切り替えボタンを追加

## Commits

- `test(backend)`: ハンドラ・ユースケースの月フィルタ関連テスト追加（mock更新、7テスト追加）
- `feat(backend)`: バックエンド実装（SQL → sqlc → repository → usecase → handler → OpenAPI）
- `feat(frontend)`: フロントエンド実装（API → hook → ExpenseCalendar → page）

## Test plan

- [ ] `cd backend && go test ./internal/...` が全パス
- [ ] `GET /expenses` → 当月の支出が返る
- [ ] `GET /expenses?year=2026&month=3` → 3月分のみ返る
- [ ] `GET /expenses?year=2026` → 400 Bad Request
- [ ] `GET /expenses?year=2026&month=13` → 400 Bad Request
- [ ] ブラウザで ‹ / › ボタンによる月移動が機能し、APIが `?year=...&month=...` 付きで呼ばれる
- [ ] リスト/カレンダー切り替えボタンが機能する
- [ ] カレンダービューで各日の支出が正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- closes: #70 
- closes: #94
- closes: #93 
- closes: #102 