### PR TITLE
 feat: #108 カテゴリーをユーザーごとに設定できるようにする

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -87,7 +87,7 @@ func main() {
 	createCategoryUC := usecase.NewCreateCategoryUseCase(categoryRepo)
 	updateCategoryUC := usecase.NewUpdateCategoryUseCase(categoryRepo)
 	deleteCategoryUC := usecase.NewDeleteCategoryUseCase(categoryRepo)
-	reorderCategoriesUC := usecase.NewReorderCategoriesUseCase(categoryRepo)
+	reorderCategoriesUC := usecase.NewReorderCategoriesUseCase(categoryRepo, txManager)
 	initialSetupUC := usecase.NewCompleteInitialSetupUseCase(userRepo, fixedCostRepo, categoryRepo, txManager)
 	getUserUC := usecase.NewGetUserUseCase(userRepo)
 	updateUserUC := usecase.NewUpdateUserSettingsUseCase(userRepo)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -84,7 +84,11 @@ func main() {
 	deleteExpenseUC := usecase.NewDeleteExpenseUseCase(expenseRepo)
 	updateExpenseUC := usecase.NewUpdateExpenseUseCase(expenseRepo, categoryRepo)
 	listCategoriesUC := usecase.NewListCategoriesUseCase(categoryRepo)
-	initialSetupUC := usecase.NewCompleteInitialSetupUseCase(userRepo, fixedCostRepo, txManager)
+	createCategoryUC := usecase.NewCreateCategoryUseCase(categoryRepo)
+	updateCategoryUC := usecase.NewUpdateCategoryUseCase(categoryRepo)
+	deleteCategoryUC := usecase.NewDeleteCategoryUseCase(categoryRepo)
+	reorderCategoriesUC := usecase.NewReorderCategoriesUseCase(categoryRepo)
+	initialSetupUC := usecase.NewCompleteInitialSetupUseCase(userRepo, fixedCostRepo, categoryRepo, txManager)
 	getUserUC := usecase.NewGetUserUseCase(userRepo)
 	updateUserUC := usecase.NewUpdateUserSettingsUseCase(userRepo)
 	createFixedCostUC := usecase.NewCreateFixedCostUseCase(fixedCostRepo)
@@ -103,7 +107,8 @@ func main() {
 	api.Use(middleware.AuthMiddleware())
 	handlers.Register(api,
 		createExpenseUC, listExpensesUC, deleteExpenseUC, updateExpenseUC,
-		listCategoriesUC, initialSetupUC, getUserUC, updateUserUC,
+		listCategoriesUC, createCategoryUC, updateCategoryUC, deleteCategoryUC, reorderCategoriesUC,
+		initialSetupUC, getUserUC, updateUserUC,
 		createFixedCostUC, listFixedCostsUC, updateFixedCostUC, deleteFixedCostUC,
 		getDashboardUC,
 	)

--- a/backend/db/generated/categories.sql.go
+++ b/backend/db/generated/categories.sql.go
@@ -175,10 +175,11 @@ func (q *Queries) UpdateUserCategory(ctx context.Context, arg UpdateUserCategory
 	return i, err
 }
 
-const updateUserCategorySortOrder = `-- name: UpdateUserCategorySortOrder :exec
+const updateUserCategorySortOrder = `-- name: UpdateUserCategorySortOrder :one
 UPDATE user_categories
 SET sort_order = $3, updated_at = now()
 WHERE id = $1 AND user_id = $2
+RETURNING id
 `
 
 type UpdateUserCategorySortOrderParams struct {
@@ -187,9 +188,11 @@ type UpdateUserCategorySortOrderParams struct {
 	SortOrder int32
 }
 
-func (q *Queries) UpdateUserCategorySortOrder(ctx context.Context, arg UpdateUserCategorySortOrderParams) error {
-	_, err := q.db.ExecContext(ctx, updateUserCategorySortOrder, arg.ID, arg.UserID, arg.SortOrder)
-	return err
+func (q *Queries) UpdateUserCategorySortOrder(ctx context.Context, arg UpdateUserCategorySortOrderParams) (int32, error) {
+	row := q.db.QueryRowContext(ctx, updateUserCategorySortOrder, arg.ID, arg.UserID, arg.SortOrder)
+	var id int32
+	err := row.Scan(&id)
+	return id, err
 }
 
 const userCategoryExists = `-- name: UserCategoryExists :one

--- a/backend/db/generated/categories.sql.go
+++ b/backend/db/generated/categories.sql.go
@@ -32,7 +32,7 @@ VALUES (
   $2,
   'user',
   COALESCE(
-    (SELECT MAX(sort_order) + 1 FROM user_categories WHERE user_id = $1 AND category_type = 'user'),
+    (SELECT MAX(sort_order) + 1 FROM user_categories WHERE user_id = $1 AND category_type != 'other'),
     1
   )
 )
@@ -82,7 +82,7 @@ SELECT id, name, category_type, sort_order
 FROM user_categories
 WHERE user_id = $1
 ORDER BY
-  CASE category_type WHEN 'default' THEN 0 WHEN 'user' THEN 1 ELSE 2 END,
+  CASE category_type WHEN 'other' THEN 1 ELSE 0 END,
   sort_order ASC,
   created_at ASC
 `

--- a/backend/db/generated/categories.sql.go
+++ b/backend/db/generated/categories.sql.go
@@ -63,8 +63,9 @@ func (q *Queries) CreateUserCategory(ctx context.Context, arg CreateUserCategory
 	return i, err
 }
 
-const deleteUserCategory = `-- name: DeleteUserCategory :exec
+const deleteUserCategory = `-- name: DeleteUserCategory :one
 DELETE FROM user_categories WHERE id = $1 AND user_id = $2
+RETURNING id
 `
 
 type DeleteUserCategoryParams struct {
@@ -72,9 +73,11 @@ type DeleteUserCategoryParams struct {
 	UserID string
 }
 
-func (q *Queries) DeleteUserCategory(ctx context.Context, arg DeleteUserCategoryParams) error {
-	_, err := q.db.ExecContext(ctx, deleteUserCategory, arg.ID, arg.UserID)
-	return err
+func (q *Queries) DeleteUserCategory(ctx context.Context, arg DeleteUserCategoryParams) (int32, error) {
+	row := q.db.QueryRowContext(ctx, deleteUserCategory, arg.ID, arg.UserID)
+	var id int32
+	err := row.Scan(&id)
+	return id, err
 }
 
 const listUserCategories = `-- name: ListUserCategories :many

--- a/backend/db/generated/categories.sql.go
+++ b/backend/db/generated/categories.sql.go
@@ -132,7 +132,7 @@ VALUES
   ($1, '医療費',     'default', 5),
   ($1, '衣服',       'default', 6),
   ($1, 'その他',     'other',   0)
-ON CONFLICT DO NOTHING
+ON CONFLICT (user_id, name) DO NOTHING
 `
 
 func (q *Queries) SeedDefaultCategoriesForUser(ctx context.Context, userID string) error {

--- a/backend/db/generated/categories.sql.go
+++ b/backend/db/generated/categories.sql.go
@@ -9,44 +9,106 @@ import (
 	"context"
 )
 
-const categoryExists = `-- name: CategoryExists :one
-SELECT EXISTS (
-  SELECT 1 
-  FROM categories 
-  WHERE id = $1
+const countExpensesByUserCategory = `-- name: CountExpensesByUserCategory :one
+SELECT COUNT(*) FROM expenses WHERE user_id = $1 AND category_id = $2
+`
+
+type CountExpensesByUserCategoryParams struct {
+	UserID     string
+	CategoryID int32
+}
+
+func (q *Queries) CountExpensesByUserCategory(ctx context.Context, arg CountExpensesByUserCategoryParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countExpensesByUserCategory, arg.UserID, arg.CategoryID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const createUserCategory = `-- name: CreateUserCategory :one
+INSERT INTO user_categories (user_id, name, category_type, sort_order)
+VALUES (
+  $1,
+  $2,
+  'user',
+  COALESCE(
+    (SELECT MAX(sort_order) + 1 FROM user_categories WHERE user_id = $1 AND category_type = 'user'),
+    1
+  )
 )
+RETURNING id, name, category_type, sort_order
 `
 
-func (q *Queries) CategoryExists(ctx context.Context, id int32) (bool, error) {
-	row := q.db.QueryRowContext(ctx, categoryExists, id)
-	var exists bool
-	err := row.Scan(&exists)
-	return exists, err
+type CreateUserCategoryParams struct {
+	UserID string
+	Name   string
 }
 
-const listCategories = `-- name: ListCategories :many
-SELECT
-  id,
-  name
-FROM categories
-ORDER BY id
+type CreateUserCategoryRow struct {
+	ID           int32
+	Name         string
+	CategoryType string
+	SortOrder    int32
+}
+
+func (q *Queries) CreateUserCategory(ctx context.Context, arg CreateUserCategoryParams) (CreateUserCategoryRow, error) {
+	row := q.db.QueryRowContext(ctx, createUserCategory, arg.UserID, arg.Name)
+	var i CreateUserCategoryRow
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.CategoryType,
+		&i.SortOrder,
+	)
+	return i, err
+}
+
+const deleteUserCategory = `-- name: DeleteUserCategory :exec
+DELETE FROM user_categories WHERE id = $1 AND user_id = $2
 `
 
-type ListCategoriesRow struct {
-	ID   int32
-	Name string
+type DeleteUserCategoryParams struct {
+	ID     int32
+	UserID string
 }
 
-func (q *Queries) ListCategories(ctx context.Context) ([]ListCategoriesRow, error) {
-	rows, err := q.db.QueryContext(ctx, listCategories)
+func (q *Queries) DeleteUserCategory(ctx context.Context, arg DeleteUserCategoryParams) error {
+	_, err := q.db.ExecContext(ctx, deleteUserCategory, arg.ID, arg.UserID)
+	return err
+}
+
+const listUserCategories = `-- name: ListUserCategories :many
+SELECT id, name, category_type, sort_order
+FROM user_categories
+WHERE user_id = $1
+ORDER BY
+  CASE category_type WHEN 'default' THEN 0 WHEN 'user' THEN 1 ELSE 2 END,
+  sort_order ASC,
+  created_at ASC
+`
+
+type ListUserCategoriesRow struct {
+	ID           int32
+	Name         string
+	CategoryType string
+	SortOrder    int32
+}
+
+func (q *Queries) ListUserCategories(ctx context.Context, userID string) ([]ListUserCategoriesRow, error) {
+	rows, err := q.db.QueryContext(ctx, listUserCategories, userID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []ListCategoriesRow
+	var items []ListUserCategoriesRow
 	for rows.Next() {
-		var i ListCategoriesRow
-		if err := rows.Scan(&i.ID, &i.Name); err != nil {
+		var i ListUserCategoriesRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.CategoryType,
+			&i.SortOrder,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -58,4 +120,89 @@ func (q *Queries) ListCategories(ctx context.Context) ([]ListCategoriesRow, erro
 		return nil, err
 	}
 	return items, nil
+}
+
+const seedDefaultCategoriesForUser = `-- name: SeedDefaultCategoriesForUser :exec
+INSERT INTO user_categories (user_id, name, category_type, sort_order)
+VALUES
+  ($1, '食費',       'default', 1),
+  ($1, '交通費',     'default', 2),
+  ($1, '日用品',     'default', 3),
+  ($1, '趣味・娯楽', 'default', 4),
+  ($1, '医療費',     'default', 5),
+  ($1, '衣服',       'default', 6),
+  ($1, 'その他',     'other',   0)
+ON CONFLICT DO NOTHING
+`
+
+func (q *Queries) SeedDefaultCategoriesForUser(ctx context.Context, userID string) error {
+	_, err := q.db.ExecContext(ctx, seedDefaultCategoriesForUser, userID)
+	return err
+}
+
+const updateUserCategory = `-- name: UpdateUserCategory :one
+UPDATE user_categories
+SET name = $3, updated_at = now()
+WHERE id = $1 AND user_id = $2
+RETURNING id, name, category_type, sort_order
+`
+
+type UpdateUserCategoryParams struct {
+	ID     int32
+	UserID string
+	Name   string
+}
+
+type UpdateUserCategoryRow struct {
+	ID           int32
+	Name         string
+	CategoryType string
+	SortOrder    int32
+}
+
+func (q *Queries) UpdateUserCategory(ctx context.Context, arg UpdateUserCategoryParams) (UpdateUserCategoryRow, error) {
+	row := q.db.QueryRowContext(ctx, updateUserCategory, arg.ID, arg.UserID, arg.Name)
+	var i UpdateUserCategoryRow
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.CategoryType,
+		&i.SortOrder,
+	)
+	return i, err
+}
+
+const updateUserCategorySortOrder = `-- name: UpdateUserCategorySortOrder :exec
+UPDATE user_categories
+SET sort_order = $3, updated_at = now()
+WHERE id = $1 AND user_id = $2
+`
+
+type UpdateUserCategorySortOrderParams struct {
+	ID        int32
+	UserID    string
+	SortOrder int32
+}
+
+func (q *Queries) UpdateUserCategorySortOrder(ctx context.Context, arg UpdateUserCategorySortOrderParams) error {
+	_, err := q.db.ExecContext(ctx, updateUserCategorySortOrder, arg.ID, arg.UserID, arg.SortOrder)
+	return err
+}
+
+const userCategoryExists = `-- name: UserCategoryExists :one
+SELECT EXISTS (
+  SELECT 1 FROM user_categories WHERE id = $1 AND user_id = $2
+)
+`
+
+type UserCategoryExistsParams struct {
+	ID     int32
+	UserID string
+}
+
+func (q *Queries) UserCategoryExists(ctx context.Context, arg UserCategoryExistsParams) (bool, error) {
+	row := q.db.QueryRowContext(ctx, userCategoryExists, arg.ID, arg.UserID)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
 }

--- a/backend/db/generated/models.go
+++ b/backend/db/generated/models.go
@@ -43,3 +43,13 @@ type User struct {
 	CreatedAt  sql.NullTime
 	UpdatedAt  sql.NullTime
 }
+
+type UserCategory struct {
+	ID           int32
+	UserID       string
+	Name         string
+	CategoryType string
+	SortOrder    int32
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}

--- a/backend/db/migration/001_user_categories.sql
+++ b/backend/db/migration/001_user_categories.sql
@@ -13,10 +13,15 @@ CREATE TABLE IF NOT EXISTS user_categories (
   sort_order INT NOT NULL DEFAULT 0,
   created_at TIMESTAMP NOT NULL DEFAULT now(),
   updated_at TIMESTAMP NOT NULL DEFAULT now(),
-  CONSTRAINT user_categories_type_check CHECK (category_type IN ('default', 'user', 'other'))
+  CONSTRAINT user_categories_type_check CHECK (category_type IN ('default', 'user', 'other')),
+  CONSTRAINT user_categories_user_name_unique UNIQUE (user_id, name)
 );
 
 CREATE INDEX IF NOT EXISTS idx_user_categories_user_id ON user_categories(user_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_categories_one_other_per_user
+  ON user_categories (user_id)
+  WHERE category_type = 'other';
 
 -- ============================================================
 -- Step 2: 既存ユーザー × 既存カテゴリ から per-user カテゴリを生成
@@ -33,7 +38,7 @@ SELECT
   now()
 FROM users u
 CROSS JOIN categories c
-ON CONFLICT DO NOTHING;
+ON CONFLICT (user_id, name) DO NOTHING;
 
 -- ============================================================
 -- Step 3: expenses.category_id を user_categories.id に更新

--- a/backend/db/migration/001_user_categories.sql
+++ b/backend/db/migration/001_user_categories.sql
@@ -1,0 +1,63 @@
+-- Migration: 001_user_categories
+-- Purpose: カテゴリをユーザーごとに管理できるようにする
+-- ※ このファイルを実行する前に必ずバックアップを取ること
+
+-- ============================================================
+-- Step 1: user_categories テーブル作成
+-- ============================================================
+CREATE TABLE IF NOT EXISTS user_categories (
+  id SERIAL PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id),
+  name TEXT NOT NULL,
+  category_type TEXT NOT NULL DEFAULT 'user',
+  sort_order INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT user_categories_type_check CHECK (category_type IN ('default', 'user', 'other'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_categories_user_id ON user_categories(user_id);
+
+-- ============================================================
+-- Step 2: 既存ユーザー × 既存カテゴリ から per-user カテゴリを生成
+--   - 'その他' という名前のカテゴリは category_type='other' にする
+--   - sort_order は旧 categories.id を流用（表示順の基準として使用）
+-- ============================================================
+INSERT INTO user_categories (user_id, name, category_type, sort_order, created_at, updated_at)
+SELECT
+  u.id AS user_id,
+  c.name,
+  CASE WHEN c.name = 'その他' THEN 'other' ELSE 'default' END AS category_type,
+  c.id AS sort_order,
+  now(),
+  now()
+FROM users u
+CROSS JOIN categories c
+ON CONFLICT DO NOTHING;
+
+-- ============================================================
+-- Step 3: expenses.category_id を user_categories.id に更新
+--   マッピング: user_categories.sort_order = 旧 categories.id かつ user_id が一致
+-- ============================================================
+ALTER TABLE expenses ADD COLUMN IF NOT EXISTS new_category_id INTEGER;
+
+UPDATE expenses e
+SET new_category_id = uc.id
+FROM user_categories uc
+WHERE uc.user_id = e.user_id
+  AND uc.sort_order = e.category_id;
+
+-- new_category_id が NULL のままの行がないことを確認してから次のステップへ
+-- SELECT COUNT(*) FROM expenses WHERE new_category_id IS NULL;
+
+-- ============================================================
+-- Step 4: category_id 列を差し替え
+-- ============================================================
+ALTER TABLE expenses DROP COLUMN category_id;
+ALTER TABLE expenses RENAME COLUMN new_category_id TO category_id;
+ALTER TABLE expenses ALTER COLUMN category_id SET NOT NULL;
+
+-- ============================================================
+-- Step 5: (オプション) 旧 categories テーブルはバックアップ後に削除可能
+--   DROP TABLE categories;
+-- ============================================================

--- a/backend/db/query/categories.sql
+++ b/backend/db/query/categories.sql
@@ -36,8 +36,9 @@ UPDATE user_categories
 SET sort_order = $3, updated_at = now()
 WHERE id = $1 AND user_id = $2;
 
--- name: DeleteUserCategory :exec
-DELETE FROM user_categories WHERE id = $1 AND user_id = $2;
+-- name: DeleteUserCategory :one
+DELETE FROM user_categories WHERE id = $1 AND user_id = $2
+RETURNING id;
 
 -- name: CountExpensesByUserCategory :one
 SELECT COUNT(*) FROM expenses WHERE user_id = $1 AND category_id = $2;

--- a/backend/db/query/categories.sql
+++ b/backend/db/query/categories.sql
@@ -31,10 +31,11 @@ SET name = $3, updated_at = now()
 WHERE id = $1 AND user_id = $2
 RETURNING id, name, category_type, sort_order;
 
--- name: UpdateUserCategorySortOrder :exec
+-- name: UpdateUserCategorySortOrder :one
 UPDATE user_categories
 SET sort_order = $3, updated_at = now()
-WHERE id = $1 AND user_id = $2;
+WHERE id = $1 AND user_id = $2
+RETURNING id;
 
 -- name: DeleteUserCategory :one
 DELETE FROM user_categories WHERE id = $1 AND user_id = $2

--- a/backend/db/query/categories.sql
+++ b/backend/db/query/categories.sql
@@ -3,7 +3,7 @@ SELECT id, name, category_type, sort_order
 FROM user_categories
 WHERE user_id = $1
 ORDER BY
-  CASE category_type WHEN 'default' THEN 0 WHEN 'user' THEN 1 ELSE 2 END,
+  CASE category_type WHEN 'other' THEN 1 ELSE 0 END,
   sort_order ASC,
   created_at ASC;
 
@@ -19,7 +19,7 @@ VALUES (
   $2,
   'user',
   COALESCE(
-    (SELECT MAX(sort_order) + 1 FROM user_categories WHERE user_id = $1 AND category_type = 'user'),
+    (SELECT MAX(sort_order) + 1 FROM user_categories WHERE user_id = $1 AND category_type != 'other'),
     1
   )
 )

--- a/backend/db/query/categories.sql
+++ b/backend/db/query/categories.sql
@@ -52,4 +52,4 @@ VALUES
   ($1, '医療費',     'default', 5),
   ($1, '衣服',       'default', 6),
   ($1, 'その他',     'other',   0)
-ON CONFLICT DO NOTHING;
+ON CONFLICT (user_id, name) DO NOTHING;

--- a/backend/db/query/categories.sql
+++ b/backend/db/query/categories.sql
@@ -1,13 +1,55 @@
--- name: ListCategories :many
-SELECT
-  id,
-  name
-FROM categories
-ORDER BY id;
+-- name: ListUserCategories :many
+SELECT id, name, category_type, sort_order
+FROM user_categories
+WHERE user_id = $1
+ORDER BY
+  CASE category_type WHEN 'default' THEN 0 WHEN 'user' THEN 1 ELSE 2 END,
+  sort_order ASC,
+  created_at ASC;
 
--- name: CategoryExists :one
+-- name: UserCategoryExists :one
 SELECT EXISTS (
-  SELECT 1 
-  FROM categories 
-  WHERE id = $1
+  SELECT 1 FROM user_categories WHERE id = $1 AND user_id = $2
 );
+
+-- name: CreateUserCategory :one
+INSERT INTO user_categories (user_id, name, category_type, sort_order)
+VALUES (
+  $1,
+  $2,
+  'user',
+  COALESCE(
+    (SELECT MAX(sort_order) + 1 FROM user_categories WHERE user_id = $1 AND category_type = 'user'),
+    1
+  )
+)
+RETURNING id, name, category_type, sort_order;
+
+-- name: UpdateUserCategory :one
+UPDATE user_categories
+SET name = $3, updated_at = now()
+WHERE id = $1 AND user_id = $2
+RETURNING id, name, category_type, sort_order;
+
+-- name: UpdateUserCategorySortOrder :exec
+UPDATE user_categories
+SET sort_order = $3, updated_at = now()
+WHERE id = $1 AND user_id = $2;
+
+-- name: DeleteUserCategory :exec
+DELETE FROM user_categories WHERE id = $1 AND user_id = $2;
+
+-- name: CountExpensesByUserCategory :one
+SELECT COUNT(*) FROM expenses WHERE user_id = $1 AND category_id = $2;
+
+-- name: SeedDefaultCategoriesForUser :exec
+INSERT INTO user_categories (user_id, name, category_type, sort_order)
+VALUES
+  ($1, '食費',       'default', 1),
+  ($1, '交通費',     'default', 2),
+  ($1, '日用品',     'default', 3),
+  ($1, '趣味・娯楽', 'default', 4),
+  ($1, '医療費',     'default', 5),
+  ($1, '衣服',       'default', 6),
+  ($1, 'その他',     'other',   0)
+ON CONFLICT DO NOTHING;

--- a/backend/db/schema/user_categories.sql
+++ b/backend/db/schema/user_categories.sql
@@ -6,7 +6,8 @@ CREATE TABLE user_categories (
   sort_order INT NOT NULL DEFAULT 0,
   created_at TIMESTAMP NOT NULL DEFAULT now(),
   updated_at TIMESTAMP NOT NULL DEFAULT now(),
-  CONSTRAINT user_categories_type_check CHECK (category_type IN ('default', 'user', 'other'))
+  CONSTRAINT user_categories_type_check CHECK (category_type IN ('default', 'user', 'other')),
+  CONSTRAINT user_categories_user_name_unique UNIQUE (user_id, name)
 );
 
 CREATE INDEX idx_user_categories_user_id ON user_categories(user_id);

--- a/backend/db/schema/user_categories.sql
+++ b/backend/db/schema/user_categories.sql
@@ -1,0 +1,12 @@
+CREATE TABLE user_categories (
+  id SERIAL PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id),
+  name TEXT NOT NULL,
+  category_type TEXT NOT NULL DEFAULT 'user',
+  sort_order INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  CONSTRAINT user_categories_type_check CHECK (category_type IN ('default', 'user', 'other'))
+);
+
+CREATE INDEX idx_user_categories_user_id ON user_categories(user_id);

--- a/backend/db/schema/user_categories.sql
+++ b/backend/db/schema/user_categories.sql
@@ -10,4 +10,8 @@ CREATE TABLE user_categories (
   CONSTRAINT user_categories_user_name_unique UNIQUE (user_id, name)
 );
 
+CREATE UNIQUE INDEX idx_user_categories_one_other_per_user
+  ON user_categories (user_id)
+  WHERE category_type = 'other';
+
 CREATE INDEX idx_user_categories_user_id ON user_categories(user_id);

--- a/backend/infra/repository/category_repository_sqlc.go
+++ b/backend/infra/repository/category_repository_sqlc.go
@@ -82,11 +82,18 @@ func (r *categoryRepositorySQLC) UpdateCategory(ctx context.Context, userID stri
 }
 
 func (r *categoryRepositorySQLC) UpdateCategorySortOrder(ctx context.Context, userID string, id int32, sortOrder int32) error {
-	return r.q.UpdateUserCategorySortOrder(ctx, db.UpdateUserCategorySortOrderParams{
+	_, err := r.q.UpdateUserCategorySortOrder(ctx, db.UpdateUserCategorySortOrderParams{
 		ID:        id,
 		UserID:    userID,
 		SortOrder: sortOrder,
 	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.ErrCategoryNotFound
+		}
+		return err
+	}
+	return nil
 }
 
 func (r *categoryRepositorySQLC) DeleteCategory(ctx context.Context, userID string, id int32) error {

--- a/backend/infra/repository/category_repository_sqlc.go
+++ b/backend/infra/repository/category_repository_sqlc.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 
 	"github.com/jackc/pgx/v5/pgconn"
@@ -89,10 +90,17 @@ func (r *categoryRepositorySQLC) UpdateCategorySortOrder(ctx context.Context, us
 }
 
 func (r *categoryRepositorySQLC) DeleteCategory(ctx context.Context, userID string, id int32) error {
-	return r.q.DeleteUserCategory(ctx, db.DeleteUserCategoryParams{
+	_, err := r.q.DeleteUserCategory(ctx, db.DeleteUserCategoryParams{
 		ID:     id,
 		UserID: userID,
 	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.ErrCategoryNotFound
+		}
+		return err
+	}
+	return nil
 }
 
 func (r *categoryRepositorySQLC) CountExpensesByCategory(ctx context.Context, userID string, categoryID int32) (int64, error) {

--- a/backend/infra/repository/category_repository_sqlc.go
+++ b/backend/infra/repository/category_repository_sqlc.go
@@ -2,10 +2,15 @@ package repository
 
 import (
 	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgconn"
 
 	db "pace-wallet-backend/db/generated"
 	"pace-wallet-backend/internal/domain"
 )
+
+
 
 
 type categoryRepositorySQLC struct {
@@ -42,6 +47,9 @@ func (r *categoryRepositorySQLC) CreateCategory(ctx context.Context, userID stri
 		Name:   name,
 	})
 	if err != nil {
+		if isUniqueViolation(err) {
+			return domain.Category{}, domain.ErrDuplicateCategoryName
+		}
 		return domain.Category{}, err
 	}
 	return domain.Category{
@@ -59,6 +67,9 @@ func (r *categoryRepositorySQLC) UpdateCategory(ctx context.Context, userID stri
 		Name:   name,
 	})
 	if err != nil {
+		if isUniqueViolation(err) {
+			return domain.Category{}, domain.ErrDuplicateCategoryName
+		}
 		return domain.Category{}, err
 	}
 	return domain.Category{
@@ -102,4 +113,10 @@ func dbUserCategoryToModel(c db.ListUserCategoriesRow) domain.Category {
 		CategoryType: c.CategoryType,
 		SortOrder:    int(c.SortOrder),
 	}
+}
+
+// isUniqueViolation は PostgreSQL の一意制約違反エラー (23505) かどうかを判定します。
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
 }

--- a/backend/infra/repository/category_repository_sqlc.go
+++ b/backend/infra/repository/category_repository_sqlc.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 
 	db "pace-wallet-backend/db/generated"
+	"pace-wallet-backend/infra/transaction"
 	"pace-wallet-backend/internal/domain"
 )
 
@@ -82,7 +83,11 @@ func (r *categoryRepositorySQLC) UpdateCategory(ctx context.Context, userID stri
 }
 
 func (r *categoryRepositorySQLC) UpdateCategorySortOrder(ctx context.Context, userID string, id int32, sortOrder int32) error {
-	_, err := r.q.UpdateUserCategorySortOrder(ctx, db.UpdateUserCategorySortOrderParams{
+	q := r.q
+	if tx, ok := transaction.TxFromContext(ctx); ok {
+		q = db.New(tx)
+	}
+	_, err := q.UpdateUserCategorySortOrder(ctx, db.UpdateUserCategorySortOrderParams{
 		ID:        id,
 		UserID:    userID,
 		SortOrder: sortOrder,

--- a/backend/infra/repository/category_repository_sqlc.go
+++ b/backend/infra/repository/category_repository_sqlc.go
@@ -7,6 +7,7 @@ import (
 	"pace-wallet-backend/internal/domain"
 )
 
+
 type categoryRepositorySQLC struct {
 	q *db.Queries
 }
@@ -15,27 +16,90 @@ func NewCategoryRepositorySQLC(q *db.Queries) *categoryRepositorySQLC {
 	return &categoryRepositorySQLC{q: q}
 }
 
-func (r *categoryRepositorySQLC) ListCategories(ctx context.Context) ([]domain.Category, error) {
-	items, err := r.q.ListCategories(ctx)
+func (r *categoryRepositorySQLC) ListCategories(ctx context.Context, userID string) ([]domain.Category, error) {
+	items, err := r.q.ListUserCategories(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
 
-	var out []domain.Category
+	out := make([]domain.Category, 0, len(items))
 	for _, it := range items {
-		out = append(out, dbCategoryToModel(it))
+		out = append(out, dbUserCategoryToModel(it))
 	}
-
 	return out, nil
 }
 
-func dbCategoryToModel(c db.ListCategoriesRow) domain.Category {
-	return domain.Category{
-		ID:   int(c.ID),
-		Name: c.Name,
-	}
+func (r *categoryRepositorySQLC) CategoryExists(ctx context.Context, userID string, id int32) (bool, error) {
+	return r.q.UserCategoryExists(ctx, db.UserCategoryExistsParams{
+		ID:     id,
+		UserID: userID,
+	})
 }
 
-func (r *categoryRepositorySQLC) CategoryExists(ctx context.Context, id int32) (bool, error) {
-	return r.q.CategoryExists(ctx, id)
+func (r *categoryRepositorySQLC) CreateCategory(ctx context.Context, userID string, name string) (domain.Category, error) {
+	row, err := r.q.CreateUserCategory(ctx, db.CreateUserCategoryParams{
+		UserID: userID,
+		Name:   name,
+	})
+	if err != nil {
+		return domain.Category{}, err
+	}
+	return domain.Category{
+		ID:           int(row.ID),
+		Name:         row.Name,
+		CategoryType: row.CategoryType,
+		SortOrder:    int(row.SortOrder),
+	}, nil
+}
+
+func (r *categoryRepositorySQLC) UpdateCategory(ctx context.Context, userID string, id int32, name string) (domain.Category, error) {
+	row, err := r.q.UpdateUserCategory(ctx, db.UpdateUserCategoryParams{
+		ID:     id,
+		UserID: userID,
+		Name:   name,
+	})
+	if err != nil {
+		return domain.Category{}, err
+	}
+	return domain.Category{
+		ID:           int(row.ID),
+		Name:         row.Name,
+		CategoryType: row.CategoryType,
+		SortOrder:    int(row.SortOrder),
+	}, nil
+}
+
+func (r *categoryRepositorySQLC) UpdateCategorySortOrder(ctx context.Context, userID string, id int32, sortOrder int32) error {
+	return r.q.UpdateUserCategorySortOrder(ctx, db.UpdateUserCategorySortOrderParams{
+		ID:        id,
+		UserID:    userID,
+		SortOrder: sortOrder,
+	})
+}
+
+func (r *categoryRepositorySQLC) DeleteCategory(ctx context.Context, userID string, id int32) error {
+	return r.q.DeleteUserCategory(ctx, db.DeleteUserCategoryParams{
+		ID:     id,
+		UserID: userID,
+	})
+}
+
+func (r *categoryRepositorySQLC) CountExpensesByCategory(ctx context.Context, userID string, categoryID int32) (int64, error) {
+	return r.q.CountExpensesByUserCategory(ctx, db.CountExpensesByUserCategoryParams{
+		UserID:     userID,
+		CategoryID: categoryID,
+	})
+}
+
+func (r *categoryRepositorySQLC) SeedDefaultCategories(ctx context.Context, userID string) error {
+	return r.q.SeedDefaultCategoriesForUser(ctx, userID)
+}
+
+func dbUserCategoryToModel(c db.ListUserCategoriesRow) domain.Category {
+	return domain.Category{
+		ID:           int(c.ID),
+		Name:         c.Name,
+		CategoryType: c.CategoryType,
+		SortOrder:    int(c.SortOrder),
+	}
 }

--- a/backend/internal/domain/category.go
+++ b/backend/internal/domain/category.go
@@ -5,6 +5,9 @@ import "errors"
 // ErrDuplicateCategoryName は同一ユーザー内でカテゴリ名が重複している場合のエラーです。
 var ErrDuplicateCategoryName = errors.New("category name already exists")
 
+// ErrCategoryNotFound はカテゴリが存在しない場合のエラーです。
+var ErrCategoryNotFound = errors.New("category not found")
+
 type Category struct {
 	ID           int    `json:"id"`
 	Name         string `json:"name"`

--- a/backend/internal/domain/category.go
+++ b/backend/internal/domain/category.go
@@ -1,6 +1,8 @@
 package domain
 
 type Category struct {
-	ID   int    `json:"id"`
-	Name string `json:"name"`
+	ID           int    `json:"id"`
+	Name         string `json:"name"`
+	CategoryType string `json:"category_type"`
+	SortOrder    int    `json:"sort_order"`
 }

--- a/backend/internal/domain/category.go
+++ b/backend/internal/domain/category.go
@@ -1,5 +1,10 @@
 package domain
 
+import "errors"
+
+// ErrDuplicateCategoryName は同一ユーザー内でカテゴリ名が重複している場合のエラーです。
+var ErrDuplicateCategoryName = errors.New("category name already exists")
+
 type Category struct {
 	ID           int    `json:"id"`
 	Name         string `json:"name"`

--- a/backend/internal/handlers/complete_initial_setup.go
+++ b/backend/internal/handlers/complete_initial_setup.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -32,7 +33,8 @@ type initialSetupRequest struct {
 func (h *CompleteInitialSetupHandler) Handle(c *gin.Context) {
 	var req initialSetupRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		log.Printf("complete_initial_setup: invalid request body: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "リクエストが不正です"})
 		return
 	}
 

--- a/backend/internal/handlers/create_category.go
+++ b/backend/internal/handlers/create_category.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -35,7 +36,8 @@ func (h *CreateCategoryHandler) Handle(c *gin.Context) {
 		Name string `json:"name"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		log.Printf("create_category: invalid request body: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "リクエストが不正です"})
 		return
 	}
 

--- a/backend/internal/handlers/create_category.go
+++ b/backend/internal/handlers/create_category.go
@@ -1,0 +1,54 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"pace-wallet-backend/internal/domain"
+	"pace-wallet-backend/internal/middleware"
+	"pace-wallet-backend/internal/usecase"
+)
+
+type createCategoryUseCase interface {
+	Execute(ctx context.Context, userID string, name string) (domain.Category, error)
+}
+
+type CreateCategoryHandler struct {
+	uc createCategoryUseCase
+}
+
+func NewCreateCategoryHandler(uc createCategoryUseCase) *CreateCategoryHandler {
+	return &CreateCategoryHandler{uc: uc}
+}
+
+func (h *CreateCategoryHandler) Handle(c *gin.Context) {
+	userID, ok := middleware.GetUserID(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	var body struct {
+		Name string `json:"name"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	cat, err := h.uc.Execute(c.Request.Context(), userID, body.Name)
+	if err != nil {
+		var ve *usecase.ValidationError
+		if errors.As(err, &ve) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": ve.Message})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "カテゴリの作成に失敗しました"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{"category": cat})
+}

--- a/backend/internal/handlers/create_expense.go
+++ b/backend/internal/handlers/create_expense.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"errors"
+	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -35,7 +36,8 @@ func (h *CreateExpenseHandler) Handle(c *gin.Context) {
 	}
 	var body createBody
 	if err := c.ShouldBindJSON(&body); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		log.Printf("create_expense: invalid request body: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "リクエストが不正です"})
 		return
 	}
 	input = usecase.CreateExpenseInput{

--- a/backend/internal/handlers/create_fixed_cost.go
+++ b/backend/internal/handlers/create_fixed_cost.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -38,7 +39,8 @@ func (h *CreateFixedCostHandler) Handle(c *gin.Context) {
 
 	var req createFixedCostRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		log.Printf("create_fixed_cost: invalid request body: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "リクエストが不正です"})
 		return
 	}
 

--- a/backend/internal/handlers/delete_category.go
+++ b/backend/internal/handlers/delete_category.go
@@ -1,0 +1,51 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"pace-wallet-backend/internal/middleware"
+	"pace-wallet-backend/internal/usecase"
+)
+
+type deleteCategoryUseCase interface {
+	Execute(ctx context.Context, userID string, id int) error
+}
+
+type DeleteCategoryHandler struct {
+	uc deleteCategoryUseCase
+}
+
+func NewDeleteCategoryHandler(uc deleteCategoryUseCase) *DeleteCategoryHandler {
+	return &DeleteCategoryHandler{uc: uc}
+}
+
+func (h *DeleteCategoryHandler) Handle(c *gin.Context) {
+	userID, ok := middleware.GetUserID(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil || id <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "無効なカテゴリIDです"})
+		return
+	}
+
+	if err := h.uc.Execute(c.Request.Context(), userID, id); err != nil {
+		var ve *usecase.ValidationError
+		if errors.As(err, &ve) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": ve.Message})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "カテゴリの削除に失敗しました"})
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}

--- a/backend/internal/handlers/delete_category.go
+++ b/backend/internal/handlers/delete_category.go
@@ -43,6 +43,11 @@ func (h *DeleteCategoryHandler) Handle(c *gin.Context) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": ve.Message})
 			return
 		}
+		var nfe *usecase.NotFoundError
+		if errors.As(err, &nfe) {
+			c.JSON(http.StatusNotFound, gin.H{"error": nfe.Message})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "カテゴリの削除に失敗しました"})
 		return
 	}

--- a/backend/internal/handlers/handler_test.go
+++ b/backend/internal/handlers/handler_test.go
@@ -386,12 +386,12 @@ func TestUpdateUserSettingsHandler_MissingIncome(t *testing.T) {
 // --- List Categories ---
 
 type mockListCategoriesUC struct {
-	fn func(ctx context.Context) ([]domain.Category, error)
+	fn func(ctx context.Context, userID string) ([]domain.Category, error)
 }
 
-func (m *mockListCategoriesUC) Execute(ctx context.Context) ([]domain.Category, error) {
+func (m *mockListCategoriesUC) Execute(ctx context.Context, userID string) ([]domain.Category, error) {
 	if m.fn != nil {
-		return m.fn(ctx)
+		return m.fn(ctx, userID)
 	}
 	return nil, nil
 }
@@ -400,7 +400,7 @@ func TestListCategoriesHandler_Success(t *testing.T) {
 	router := newRouterWithUserID("user1")
 
 	uc := &mockListCategoriesUC{
-		fn: func(ctx context.Context) ([]domain.Category, error) {
+		fn: func(ctx context.Context, userID string) ([]domain.Category, error) {
 			return []domain.Category{{ID: 1, Name: "食費"}, {ID: 2, Name: "交通費"}}, nil
 		},
 	}

--- a/backend/internal/handlers/handler_test.go
+++ b/backend/internal/handlers/handler_test.go
@@ -415,3 +415,329 @@ func TestListCategoriesHandler_Success(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Len(t, resp["categories"], 2)
 }
+
+// --- Create Category ---
+
+type mockCreateCategoryUC struct {
+	fn func(ctx context.Context, userID string, name string) (domain.Category, error)
+}
+
+func (m *mockCreateCategoryUC) Execute(ctx context.Context, userID string, name string) (domain.Category, error) {
+	if m.fn != nil {
+		return m.fn(ctx, userID, name)
+	}
+	return domain.Category{}, nil
+}
+
+func TestCreateCategoryHandler_Success(t *testing.T) {
+	router := newRouterWithUserID("user1")
+
+	uc := &mockCreateCategoryUC{
+		fn: func(ctx context.Context, userID string, name string) (domain.Category, error) {
+			require.Equal(t, "user1", userID)
+			return domain.Category{ID: 10, Name: name, CategoryType: "user", SortOrder: 1}, nil
+		},
+	}
+	router.POST("/categories", NewCreateCategoryHandler(uc).Handle)
+
+	req := httptest.NewRequest(http.MethodPost, "/categories", strings.NewReader(`{"name":"外食"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	var resp map[string]domain.Category
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, 10, resp["category"].ID)
+	require.Equal(t, "外食", resp["category"].Name)
+}
+
+func TestCreateCategoryHandler_EmptyName(t *testing.T) {
+	router := newRouterWithUserID("user1")
+
+	uc := &mockCreateCategoryUC{
+		fn: func(ctx context.Context, userID string, name string) (domain.Category, error) {
+			return domain.Category{}, &usecase.ValidationError{Message: "カテゴリ名を入力してください"}
+		},
+	}
+	router.POST("/categories", NewCreateCategoryHandler(uc).Handle)
+
+	req := httptest.NewRequest(http.MethodPost, "/categories", strings.NewReader(`{"name":""}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, "カテゴリ名を入力してください", resp["error"])
+}
+
+func TestCreateCategoryHandler_DuplicateName(t *testing.T) {
+	router := newRouterWithUserID("user1")
+
+	uc := &mockCreateCategoryUC{
+		fn: func(ctx context.Context, userID string, name string) (domain.Category, error) {
+			return domain.Category{}, &usecase.ValidationError{Message: "同じ名前のカテゴリがすでに存在します"}
+		},
+	}
+	router.POST("/categories", NewCreateCategoryHandler(uc).Handle)
+
+	req := httptest.NewRequest(http.MethodPost, "/categories", strings.NewReader(`{"name":"食費"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, "同じ名前のカテゴリがすでに存在します", resp["error"])
+}
+
+// --- Update Category ---
+
+type mockUpdateCategoryUC struct {
+	fn func(ctx context.Context, userID string, id int, name string) (domain.Category, error)
+}
+
+func (m *mockUpdateCategoryUC) Execute(ctx context.Context, userID string, id int, name string) (domain.Category, error) {
+	if m.fn != nil {
+		return m.fn(ctx, userID, id, name)
+	}
+	return domain.Category{}, nil
+}
+
+func TestUpdateCategoryHandler_Success(t *testing.T) {
+	router := newRouterWithUserID("user1")
+
+	uc := &mockUpdateCategoryUC{
+		fn: func(ctx context.Context, userID string, id int, name string) (domain.Category, error) {
+			require.Equal(t, "user1", userID)
+			require.Equal(t, 3, id)
+			return domain.Category{ID: id, Name: name, CategoryType: "user", SortOrder: 1}, nil
+		},
+	}
+	router.PUT("/categories/:id", NewUpdateCategoryHandler(uc).Handle)
+
+	req := httptest.NewRequest(http.MethodPut, "/categories/3", strings.NewReader(`{"name":"外食費"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]domain.Category
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, "外食費", resp["category"].Name)
+}
+
+func TestUpdateCategoryHandler_OtherUserCategory_NotFound(t *testing.T) {
+	// usecase は userID を条件に含めるため、他ユーザーのカテゴリは NotFoundError になる
+	router := newRouterWithUserID("user1")
+
+	uc := &mockUpdateCategoryUC{
+		fn: func(ctx context.Context, userID string, id int, name string) (domain.Category, error) {
+			return domain.Category{}, &usecase.NotFoundError{Message: "カテゴリが見つかりません"}
+		},
+	}
+	router.PUT("/categories/:id", NewUpdateCategoryHandler(uc).Handle)
+
+	req := httptest.NewRequest(http.MethodPut, "/categories/999", strings.NewReader(`{"name":"外食費"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestUpdateCategoryHandler_DuplicateName(t *testing.T) {
+	router := newRouterWithUserID("user1")
+
+	uc := &mockUpdateCategoryUC{
+		fn: func(ctx context.Context, userID string, id int, name string) (domain.Category, error) {
+			return domain.Category{}, &usecase.ValidationError{Message: "同じ名前のカテゴリがすでに存在します"}
+		},
+	}
+	router.PUT("/categories/:id", NewUpdateCategoryHandler(uc).Handle)
+
+	req := httptest.NewRequest(http.MethodPut, "/categories/3", strings.NewReader(`{"name":"食費"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, "同じ名前のカテゴリがすでに存在します", resp["error"])
+}
+
+func TestUpdateCategoryHandler_InvalidID(t *testing.T) {
+	router := newRouterWithUserID("user1")
+
+	uc := &mockUpdateCategoryUC{}
+	router.PUT("/categories/:id", NewUpdateCategoryHandler(uc).Handle)
+
+	req := httptest.NewRequest(http.MethodPut, "/categories/abc", strings.NewReader(`{"name":"外食費"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// --- Delete Category ---
+
+type mockDeleteCategoryUC struct {
+	fn func(ctx context.Context, userID string, id int) error
+}
+
+func (m *mockDeleteCategoryUC) Execute(ctx context.Context, userID string, id int) error {
+	if m.fn != nil {
+		return m.fn(ctx, userID, id)
+	}
+	return nil
+}
+
+func TestDeleteCategoryHandler_Success(t *testing.T) {
+	router := newRouterWithUserID("user1")
+
+	called := false
+	uc := &mockDeleteCategoryUC{
+		fn: func(ctx context.Context, userID string, id int) error {
+			called = true
+			require.Equal(t, "user1", userID)
+			require.Equal(t, 5, id)
+			return nil
+		},
+	}
+	router.DELETE("/categories/:id", NewDeleteCategoryHandler(uc).Handle)
+
+	req := httptest.NewRequest(http.MethodDelete, "/categories/5", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+	require.True(t, called)
+}
+
+func TestDeleteCategoryHandler_OtherUserCategory_NotFound(t *testing.T) {
+	// usecase は userID を条件に含めるため、他ユーザーのカテゴリは NotFoundError になる
+	router := newRouterWithUserID("user1")
+
+	uc := &mockDeleteCategoryUC{
+		fn: func(ctx context.Context, userID string, id int) error {
+			return &usecase.NotFoundError{Message: "カテゴリが見つかりません"}
+		},
+	}
+	router.DELETE("/categories/:id", NewDeleteCategoryHandler(uc).Handle)
+
+	req := httptest.NewRequest(http.MethodDelete, "/categories/999", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestDeleteCategoryHandler_ReferencedByExpense(t *testing.T) {
+	router := newRouterWithUserID("user1")
+
+	uc := &mockDeleteCategoryUC{
+		fn: func(ctx context.Context, userID string, id int) error {
+			return &usecase.ValidationError{Message: "このカテゴリは支出で使用されているため削除できません"}
+		},
+	}
+	router.DELETE("/categories/:id", NewDeleteCategoryHandler(uc).Handle)
+
+	req := httptest.NewRequest(http.MethodDelete, "/categories/1", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, "このカテゴリは支出で使用されているため削除できません", resp["error"])
+}
+
+func TestDeleteCategoryHandler_InvalidID(t *testing.T) {
+	router := newRouterWithUserID("user1")
+
+	uc := &mockDeleteCategoryUC{}
+	router.DELETE("/categories/:id", NewDeleteCategoryHandler(uc).Handle)
+
+	req := httptest.NewRequest(http.MethodDelete, "/categories/0", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// --- Reorder Categories ---
+
+type mockReorderCategoriesUC struct {
+	fn func(ctx context.Context, userID string, items []usecase.ReorderCategoriesInput) error
+}
+
+func (m *mockReorderCategoriesUC) Execute(ctx context.Context, userID string, items []usecase.ReorderCategoriesInput) error {
+	if m.fn != nil {
+		return m.fn(ctx, userID, items)
+	}
+	return nil
+}
+
+func TestReorderCategoriesHandler_Success(t *testing.T) {
+	router := newRouterWithUserID("user1")
+
+	var gotItems []usecase.ReorderCategoriesInput
+	uc := &mockReorderCategoriesUC{
+		fn: func(ctx context.Context, userID string, items []usecase.ReorderCategoriesInput) error {
+			require.Equal(t, "user1", userID)
+			gotItems = items
+			return nil
+		},
+	}
+	router.PUT("/categories/reorder", NewReorderCategoriesHandler(uc).Handle)
+
+	body := `{"items":[{"id":2,"sort_order":1},{"id":1,"sort_order":2}]}`
+	req := httptest.NewRequest(http.MethodPut, "/categories/reorder", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+	require.Len(t, gotItems, 2)
+	require.Equal(t, 2, gotItems[0].ID)
+	require.Equal(t, 1, gotItems[0].SortOrder)
+}
+
+func TestReorderCategoriesHandler_UnknownID_NotFound(t *testing.T) {
+	// 存在しないIDや他ユーザーのIDが混ざっていた場合は NotFoundError → 404
+	router := newRouterWithUserID("user1")
+
+	uc := &mockReorderCategoriesUC{
+		fn: func(ctx context.Context, userID string, items []usecase.ReorderCategoriesInput) error {
+			return &usecase.NotFoundError{Message: "カテゴリが見つかりません"}
+		},
+	}
+	router.PUT("/categories/reorder", NewReorderCategoriesHandler(uc).Handle)
+
+	body := `{"items":[{"id":999,"sort_order":1}]}`
+	req := httptest.NewRequest(http.MethodPut, "/categories/reorder", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestReorderCategoriesHandler_InvalidJSON(t *testing.T) {
+	router := newRouterWithUserID("user1")
+
+	uc := &mockReorderCategoriesUC{}
+	router.PUT("/categories/reorder", NewReorderCategoriesHandler(uc).Handle)
+
+	req := httptest.NewRequest(http.MethodPut, "/categories/reorder", strings.NewReader(`not-json`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/backend/internal/handlers/list_categories.go
+++ b/backend/internal/handlers/list_categories.go
@@ -7,10 +7,11 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"pace-wallet-backend/internal/domain"
+	"pace-wallet-backend/internal/middleware"
 )
 
 type listCategoriesUseCase interface {
-	Execute(ctx context.Context) ([]domain.Category, error)
+	Execute(ctx context.Context, userID string) ([]domain.Category, error)
 }
 
 type ListCategoriesHandler struct {
@@ -22,7 +23,13 @@ func NewListCategoriesHandler(uc listCategoriesUseCase) *ListCategoriesHandler {
 }
 
 func (h *ListCategoriesHandler) Handle(c *gin.Context) {
-	categories, err := h.uc.Execute(c.Request.Context())
+	userID, ok := middleware.GetUserID(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	categories, err := h.uc.Execute(c.Request.Context(), userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "カテゴリの取得に失敗しました"})
 		return

--- a/backend/internal/handlers/register.go
+++ b/backend/internal/handlers/register.go
@@ -14,6 +14,10 @@ func Register(
 	deleteExpense *usecase.DeleteExpenseUseCase,
 	updateExpense *usecase.UpdateExpenseUseCase,
 	listCategories *usecase.ListCategoriesUseCase,
+	createCategory *usecase.CreateCategoryUseCase,
+	updateCategory *usecase.UpdateCategoryUseCase,
+	deleteCategory *usecase.DeleteCategoryUseCase,
+	reorderCategories *usecase.ReorderCategoriesUseCase,
 	initialSetup *usecase.CompleteInitialSetupUseCase,
 	getUser *usecase.GetUserUseCase,
 	updateUser *usecase.UpdateUserSettingsUseCase,
@@ -27,7 +31,14 @@ func Register(
 	r.GET("/expenses", NewListExpensesHandler(listExpenses).Handle)
 	r.DELETE("/expenses/:id", NewDeleteExpenseHandler(deleteExpense).Handle)
 	r.PUT("/expenses/:id", NewUpdateExpenseHandler(updateExpense).Handle)
+
+	// categories - /categories/reorder を /:id より先に登録
 	r.GET("/categories", NewListCategoriesHandler(listCategories).Handle)
+	r.POST("/categories", NewCreateCategoryHandler(createCategory).Handle)
+	r.PUT("/categories/reorder", NewReorderCategoriesHandler(reorderCategories).Handle)
+	r.PUT("/categories/:id", NewUpdateCategoryHandler(updateCategory).Handle)
+	r.DELETE("/categories/:id", NewDeleteCategoryHandler(deleteCategory).Handle)
+
 	r.POST("/setup", NewCompleteInitialSetupHandler(initialSetup).Handle)
 	r.GET("/user/me", NewGetUserHandler(getUser).Handle)
 	r.PUT("/user/me", NewUpdateUserSettingsHandler(updateUser).Handle)

--- a/backend/internal/handlers/reorder_categories.go
+++ b/backend/internal/handlers/reorder_categories.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -34,7 +35,8 @@ func (h *ReorderCategoriesHandler) Handle(c *gin.Context) {
 		Items []usecase.ReorderCategoriesInput `json:"items"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		log.Printf("reorder_categories: invalid request body: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "リクエストが不正です"})
 		return
 	}
 

--- a/backend/internal/handlers/reorder_categories.go
+++ b/backend/internal/handlers/reorder_categories.go
@@ -39,9 +39,9 @@ func (h *ReorderCategoriesHandler) Handle(c *gin.Context) {
 	}
 
 	if err := h.uc.Execute(c.Request.Context(), userID, body.Items); err != nil {
-		var ie *usecase.InternalError
-		if errors.As(err, &ie) {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "並び替えに失敗しました"})
+		var nfe *usecase.NotFoundError
+		if errors.As(err, &nfe) {
+			c.JSON(http.StatusNotFound, gin.H{"error": nfe.Message})
 			return
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "並び替えに失敗しました"})

--- a/backend/internal/handlers/reorder_categories.go
+++ b/backend/internal/handlers/reorder_categories.go
@@ -1,0 +1,52 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"pace-wallet-backend/internal/middleware"
+	"pace-wallet-backend/internal/usecase"
+)
+
+type reorderCategoriesUseCase interface {
+	Execute(ctx context.Context, userID string, items []usecase.ReorderCategoriesInput) error
+}
+
+type ReorderCategoriesHandler struct {
+	uc reorderCategoriesUseCase
+}
+
+func NewReorderCategoriesHandler(uc reorderCategoriesUseCase) *ReorderCategoriesHandler {
+	return &ReorderCategoriesHandler{uc: uc}
+}
+
+func (h *ReorderCategoriesHandler) Handle(c *gin.Context) {
+	userID, ok := middleware.GetUserID(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	var body struct {
+		Items []usecase.ReorderCategoriesInput `json:"items"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := h.uc.Execute(c.Request.Context(), userID, body.Items); err != nil {
+		var ie *usecase.InternalError
+		if errors.As(err, &ie) {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "並び替えに失敗しました"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "並び替えに失敗しました"})
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}

--- a/backend/internal/handlers/update_category.go
+++ b/backend/internal/handlers/update_category.go
@@ -1,0 +1,66 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"pace-wallet-backend/internal/domain"
+	"pace-wallet-backend/internal/middleware"
+	"pace-wallet-backend/internal/usecase"
+)
+
+type updateCategoryUseCase interface {
+	Execute(ctx context.Context, userID string, id int, name string) (domain.Category, error)
+}
+
+type UpdateCategoryHandler struct {
+	uc updateCategoryUseCase
+}
+
+func NewUpdateCategoryHandler(uc updateCategoryUseCase) *UpdateCategoryHandler {
+	return &UpdateCategoryHandler{uc: uc}
+}
+
+func (h *UpdateCategoryHandler) Handle(c *gin.Context) {
+	userID, ok := middleware.GetUserID(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil || id <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "無効なカテゴリIDです"})
+		return
+	}
+
+	var body struct {
+		Name string `json:"name"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	cat, err := h.uc.Execute(c.Request.Context(), userID, id, body.Name)
+	if err != nil {
+		var ve *usecase.ValidationError
+		if errors.As(err, &ve) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": ve.Message})
+			return
+		}
+		var nfe *usecase.NotFoundError
+		if errors.As(err, &nfe) {
+			c.JSON(http.StatusNotFound, gin.H{"error": nfe.Message})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "カテゴリの更新に失敗しました"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"category": cat})
+}

--- a/backend/internal/handlers/update_category.go
+++ b/backend/internal/handlers/update_category.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -42,7 +43,8 @@ func (h *UpdateCategoryHandler) Handle(c *gin.Context) {
 		Name string `json:"name"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		log.Printf("update_category: invalid request body: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "リクエストが不正です"})
 		return
 	}
 

--- a/backend/internal/handlers/update_expense.go
+++ b/backend/internal/handlers/update_expense.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"errors"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -44,7 +45,8 @@ func (h *UpdateExpenseHandler) Handle(c *gin.Context) {
 	}
 	var body updateBody
 	if err := c.ShouldBindJSON(&body); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		log.Printf("update_expense: invalid request body: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "リクエストが不正です"})
 		return
 	}
 

--- a/backend/internal/handlers/update_fixed_cost.go
+++ b/backend/internal/handlers/update_fixed_cost.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -50,7 +51,8 @@ func (h *UpdateFixedCostHandler) Handle(c *gin.Context) {
 
 	var req updateFixedCostRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		log.Printf("update_fixed_cost: invalid request body: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "リクエストが不正です"})
 		return
 	}
 

--- a/backend/internal/handlers/update_user_settings.go
+++ b/backend/internal/handlers/update_user_settings.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -37,7 +38,8 @@ func (h *UpdateUserSettingsHandler) Handle(c *gin.Context) {
 
 	var req updateUserSettingsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "リクエストの形式が正しくありません"})
+		log.Printf("update_user_settings: invalid request body: %v", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "リクエストが不正です"})
 		return
 	}
 

--- a/backend/internal/usecase/complete_initial_setup.go
+++ b/backend/internal/usecase/complete_initial_setup.go
@@ -31,10 +31,15 @@ type completeInitialSetupFixedCostRepository interface {
 	BulkCreateFixedCosts(ctx context.Context, userID string, fixedCosts []FixedCostItem) error
 }
 
+type completeInitialSetupCategoryRepository interface {
+	SeedDefaultCategories(ctx context.Context, userID string) error
+}
+
 // CompleteInitialSetupUseCase は初期設定完了ユースケースです。
 type CompleteInitialSetupUseCase struct {
-	userRepo      completeInitialSetupUserRepository
+	userRepo     completeInitialSetupUserRepository
 	fixedCostRepo completeInitialSetupFixedCostRepository
+	categoryRepo  completeInitialSetupCategoryRepository
 	txManager     TxManager
 }
 
@@ -42,11 +47,13 @@ type CompleteInitialSetupUseCase struct {
 func NewCompleteInitialSetupUseCase(
 	userRepo completeInitialSetupUserRepository,
 	fixedCostRepo completeInitialSetupFixedCostRepository,
+	categoryRepo completeInitialSetupCategoryRepository,
 	txManager TxManager,
 ) *CompleteInitialSetupUseCase {
 	return &CompleteInitialSetupUseCase{
 		userRepo:      userRepo,
 		fixedCostRepo: fixedCostRepo,
+		categoryRepo:  categoryRepo,
 		txManager:     txManager,
 	}
 }
@@ -97,6 +104,7 @@ func (uc *CompleteInitialSetupUseCase) Execute(ctx context.Context, userID strin
 
 	txCtx := tx.Context(ctx)
 
+	isNewUser := false
 	user, err := uc.userRepo.GetUserByID(txCtx, userID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -104,12 +112,20 @@ func (uc *CompleteInitialSetupUseCase) Execute(ctx context.Context, userID strin
 				_ = tx.Rollback()
 				return err
 			}
+			isNewUser = true
 		} else {
 			_ = tx.Rollback()
 			return err
 		}
 	} else if user != (domain.User{}) {
 		if err := uc.userRepo.UpdateUserSettings(txCtx, userID, income, savingGoal); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+	}
+
+	if isNewUser {
+		if err := uc.categoryRepo.SeedDefaultCategories(txCtx, userID); err != nil {
 			_ = tx.Rollback()
 			return err
 		}

--- a/backend/internal/usecase/complete_initial_setup_test.go
+++ b/backend/internal/usecase/complete_initial_setup_test.go
@@ -16,6 +16,7 @@ type txMock struct{ mock.Mock }
 type txManagerMock struct{ mock.Mock }
 type userRepoMock struct{ mock.Mock }
 type setupFixedCostRepoMock struct{ mock.Mock }
+type setupCategoryRepoMock struct{ mock.Mock }
 
 func (m *txMock) Commit() error {
 	args := m.Called()
@@ -67,6 +68,11 @@ func (m *setupFixedCostRepoMock) BulkCreateFixedCosts(ctx context.Context, userI
 	return args.Error(0)
 }
 
+func (m *setupCategoryRepoMock) SeedDefaultCategories(ctx context.Context, userID string) error {
+	args := m.Called(ctx, userID)
+	return args.Error(0)
+}
+
 func TestCompleteInitialSetup(t *testing.T) {
 	userID := "user-1"
 	validFixedCosts := []FixedCostItem{
@@ -79,7 +85,7 @@ func TestCompleteInitialSetup(t *testing.T) {
 		income       int
 		savingGoal   int
 		fixedCosts   []FixedCostItem
-		setupMocks   func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, calls *[]string)
+		setupMocks   func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, cr *setupCategoryRepoMock, calls *[]string)
 		wantErr      bool
 		wantValidate bool
 		wantCommit   bool
@@ -91,17 +97,18 @@ func TestCompleteInitialSetup(t *testing.T) {
 			income:     300000,
 			savingGoal: 50000,
 			fixedCosts: validFixedCosts,
-			setupMocks: func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, calls *[]string) {
+			setupMocks: func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, cr *setupCategoryRepoMock, calls *[]string) {
 				tm.On("Begin", mock.Anything).Run(func(args mock.Arguments) { *calls = append(*calls, "begin") }).Return(tx, nil)
 				ur.On("GetUserByID", mock.Anything, userID).Run(func(args mock.Arguments) { *calls = append(*calls, "get_user") }).Return(domain.User{}, sql.ErrNoRows)
 				ur.On("CreateUser", mock.Anything, userID, 300000, 50000).Run(func(args mock.Arguments) { *calls = append(*calls, "create_user") }).Return(nil)
+				cr.On("SeedDefaultCategories", mock.Anything, userID).Run(func(args mock.Arguments) { *calls = append(*calls, "seed_categories") }).Return(nil)
 				fr.On("DeleteFixedCostsByUser", mock.Anything, userID).Run(func(args mock.Arguments) { *calls = append(*calls, "delete_fixed") }).Return(nil)
 				fr.On("BulkCreateFixedCosts", mock.Anything, userID, validFixedCosts).Run(func(args mock.Arguments) { *calls = append(*calls, "bulk_create") }).Return(nil)
 				tx.On("Commit").Run(func(args mock.Arguments) { *calls = append(*calls, "commit") }).Return(nil)
 			},
 			wantCommit:   true,
 			wantRollback: false,
-			wantCalls:    []string{"begin", "get_user", "create_user", "delete_fixed", "bulk_create", "commit"},
+			wantCalls:    []string{"begin", "get_user", "create_user", "seed_categories", "delete_fixed", "bulk_create", "commit"},
 		},
 		{
 			name:       "固定費名が前後に空白を含む場合トリムされる",
@@ -111,10 +118,11 @@ func TestCompleteInitialSetup(t *testing.T) {
 				{Name: "  rent  ", Amount: 50000},
 				{Name: "phone", Amount: 6000},
 			},
-			setupMocks: func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, calls *[]string) {
+			setupMocks: func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, cr *setupCategoryRepoMock, calls *[]string) {
 				tm.On("Begin", mock.Anything).Return(tx, nil)
 				ur.On("GetUserByID", mock.Anything, userID).Return(domain.User{}, sql.ErrNoRows)
 				ur.On("CreateUser", mock.Anything, userID, 300000, 50000).Return(nil)
+				cr.On("SeedDefaultCategories", mock.Anything, userID).Return(nil)
 				fr.On("DeleteFixedCostsByUser", mock.Anything, userID).Return(nil)
 				trimmedFixedCosts := []FixedCostItem{
 					{Name: "rent", Amount: 50000},
@@ -131,7 +139,7 @@ func TestCompleteInitialSetup(t *testing.T) {
 			income:       0,
 			savingGoal:   0,
 			fixedCosts:   validFixedCosts,
-			setupMocks:   func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, calls *[]string) {},
+			setupMocks:   func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, cr *setupCategoryRepoMock, calls *[]string) {},
 			wantErr:      true,
 			wantValidate: true,
 		},
@@ -140,7 +148,7 @@ func TestCompleteInitialSetup(t *testing.T) {
 			income:       100,
 			savingGoal:   0,
 			fixedCosts:   []FixedCostItem{{Name: "rent", Amount: 0}},
-			setupMocks:   func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, calls *[]string) {},
+			setupMocks:   func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, cr *setupCategoryRepoMock, calls *[]string) {},
 			wantErr:      true,
 			wantValidate: true,
 		},
@@ -149,7 +157,7 @@ func TestCompleteInitialSetup(t *testing.T) {
 			income:       100,
 			savingGoal:   0,
 			fixedCosts:   []FixedCostItem{{Name: "rent", Amount: BusinessMaxAmount + 1}},
-			setupMocks:   func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, calls *[]string) {},
+			setupMocks:   func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, cr *setupCategoryRepoMock, calls *[]string) {},
 			wantErr:      true,
 			wantValidate: true,
 		},
@@ -158,7 +166,7 @@ func TestCompleteInitialSetup(t *testing.T) {
 			income:       100,
 			savingGoal:   0,
 			fixedCosts:   []FixedCostItem{{Name: "", Amount: 10000}},
-			setupMocks:   func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, calls *[]string) {},
+			setupMocks:   func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, cr *setupCategoryRepoMock, calls *[]string) {},
 			wantErr:      true,
 			wantValidate: true,
 		},
@@ -167,7 +175,7 @@ func TestCompleteInitialSetup(t *testing.T) {
 			income:       100,
 			savingGoal:   0,
 			fixedCosts:   []FixedCostItem{{Name: "   ", Amount: 10000}},
-			setupMocks:   func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, calls *[]string) {},
+			setupMocks:   func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, cr *setupCategoryRepoMock, calls *[]string) {},
 			wantErr:      true,
 			wantValidate: true,
 		},
@@ -176,7 +184,7 @@ func TestCompleteInitialSetup(t *testing.T) {
 			income:       100,
 			savingGoal:   0,
 			fixedCosts:   []FixedCostItem{{Name: string(make([]byte, 101)), Amount: 10000}},
-			setupMocks:   func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, calls *[]string) {},
+			setupMocks:   func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, cr *setupCategoryRepoMock, calls *[]string) {},
 			wantErr:      true,
 			wantValidate: true,
 		},
@@ -185,7 +193,7 @@ func TestCompleteInitialSetup(t *testing.T) {
 			income:     100,
 			savingGoal: 0,
 			fixedCosts: validFixedCosts,
-			setupMocks: func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, calls *[]string) {
+			setupMocks: func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, cr *setupCategoryRepoMock, calls *[]string) {
 				tm.On("Begin", mock.Anything).Run(func(args mock.Arguments) { *calls = append(*calls, "begin") }).Return(tx, nil)
 				ur.On("GetUserByID", mock.Anything, userID).Run(func(args mock.Arguments) { *calls = append(*calls, "get_user") }).Return(domain.User{ID: userID}, nil)
 				ur.On("UpdateUserSettings", mock.Anything, userID, 100, 0).Run(func(args mock.Arguments) { *calls = append(*calls, "update_user") }).Return(nil)
@@ -202,7 +210,7 @@ func TestCompleteInitialSetup(t *testing.T) {
 			income:     100,
 			savingGoal: 0,
 			fixedCosts: validFixedCosts,
-			setupMocks: func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, calls *[]string) {
+			setupMocks: func(tx *txMock, tm *txManagerMock, ur *userRepoMock, fr *setupFixedCostRepoMock, cr *setupCategoryRepoMock, calls *[]string) {
 				tm.On("Begin", mock.Anything).Run(func(args mock.Arguments) { *calls = append(*calls, "begin") }).Return(tx, nil)
 				ur.On("GetUserByID", mock.Anything, userID).Run(func(args mock.Arguments) { *calls = append(*calls, "get_user") }).Return(domain.User{ID: userID}, nil)
 				ur.On("UpdateUserSettings", mock.Anything, userID, 100, 0).Run(func(args mock.Arguments) { *calls = append(*calls, "update_user") }).Return(nil)
@@ -226,13 +234,14 @@ func TestCompleteInitialSetup(t *testing.T) {
 			tm := &txManagerMock{}
 			ur := &userRepoMock{}
 			fr := &setupFixedCostRepoMock{}
+			cr := &setupCategoryRepoMock{}
 			calls := []string{}
 
 			if tc.setupMocks != nil {
-				tc.setupMocks(tx, tm, ur, fr, &calls)
+				tc.setupMocks(tx, tm, ur, fr, cr, &calls)
 			}
 
-			uc := NewCompleteInitialSetupUseCase(ur, fr, tm)
+			uc := NewCompleteInitialSetupUseCase(ur, fr, cr, tm)
 			err := uc.Execute(context.Background(), userID, tc.income, tc.savingGoal, tc.fixedCosts)
 
 			if tc.wantErr {
@@ -263,6 +272,7 @@ func TestCompleteInitialSetup(t *testing.T) {
 			tm.AssertExpectations(t)
 			ur.AssertExpectations(t)
 			fr.AssertExpectations(t)
+			cr.AssertExpectations(t)
 			tx.AssertExpectations(t)
 		})
 	}

--- a/backend/internal/usecase/create_category.go
+++ b/backend/internal/usecase/create_category.go
@@ -2,10 +2,12 @@ package usecase
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"pace-wallet-backend/internal/domain"
 )
+
 
 const CategoryNameMaxLen = 50
 
@@ -33,5 +35,12 @@ func (uc *CreateCategoryUseCase) Execute(ctx context.Context, userID string, nam
 		return domain.Category{}, &ValidationError{Message: "カテゴリ名は50文字以内で入力してください"}
 	}
 
-	return uc.repo.CreateCategory(ctx, userID, name)
+	cat, err := uc.repo.CreateCategory(ctx, userID, name)
+	if err != nil {
+		if errors.Is(err, domain.ErrDuplicateCategoryName) {
+			return domain.Category{}, &ValidationError{Message: "同じ名前のカテゴリがすでに存在します"}
+		}
+		return domain.Category{}, &InternalError{Message: "internal error"}
+	}
+	return cat, nil
 }

--- a/backend/internal/usecase/create_category.go
+++ b/backend/internal/usecase/create_category.go
@@ -1,0 +1,37 @@
+package usecase
+
+import (
+	"context"
+	"strings"
+
+	"pace-wallet-backend/internal/domain"
+)
+
+const CategoryNameMaxLen = 50
+
+type createCategoryRepository interface {
+	CreateCategory(ctx context.Context, userID string, name string) (domain.Category, error)
+}
+
+// CreateCategoryUseCase はカテゴリ作成ユースケースです。
+type CreateCategoryUseCase struct {
+	repo createCategoryRepository
+}
+
+// NewCreateCategoryUseCase は CreateCategoryUseCase の新しいインスタンスを生成します。
+func NewCreateCategoryUseCase(repo createCategoryRepository) *CreateCategoryUseCase {
+	return &CreateCategoryUseCase{repo: repo}
+}
+
+// Execute はカテゴリ作成ユースケースを実行します。
+func (uc *CreateCategoryUseCase) Execute(ctx context.Context, userID string, name string) (domain.Category, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return domain.Category{}, &ValidationError{Message: "カテゴリ名を入力してください"}
+	}
+	if len([]rune(name)) > CategoryNameMaxLen {
+		return domain.Category{}, &ValidationError{Message: "カテゴリ名は50文字以内で入力してください"}
+	}
+
+	return uc.repo.CreateCategory(ctx, userID, name)
+}

--- a/backend/internal/usecase/create_expense.go
+++ b/backend/internal/usecase/create_expense.go
@@ -29,7 +29,7 @@ type createExpenseRepository interface {
 }
 
 type categoryExistsChecker interface {
-	CategoryExists(ctx context.Context, id int32) (bool, error)
+	CategoryExists(ctx context.Context, userID string, id int32) (bool, error)
 }
 
 type CreateExpenseUseCase struct {
@@ -91,7 +91,7 @@ func (uc *CreateExpenseUseCase) Execute(userID string, input CreateExpenseInput)
 		}
 	}
 
-	exists, err := uc.category.CategoryExists(context.Background(), int32(*input.CategoryID))
+	exists, err := uc.category.CategoryExists(context.Background(), userID, int32(*input.CategoryID))
 	if err != nil {
 		return domain.Expense{}, &InternalError{Message: "internal error"}
 	}

--- a/backend/internal/usecase/delete_category.go
+++ b/backend/internal/usecase/delete_category.go
@@ -1,0 +1,33 @@
+package usecase
+
+import (
+	"context"
+)
+
+type deleteCategoryRepository interface {
+	CountExpensesByCategory(ctx context.Context, userID string, categoryID int32) (int64, error)
+	DeleteCategory(ctx context.Context, userID string, id int32) error
+}
+
+// DeleteCategoryUseCase はカテゴリ削除ユースケースです。
+type DeleteCategoryUseCase struct {
+	repo deleteCategoryRepository
+}
+
+// NewDeleteCategoryUseCase は DeleteCategoryUseCase の新しいインスタンスを生成します。
+func NewDeleteCategoryUseCase(repo deleteCategoryRepository) *DeleteCategoryUseCase {
+	return &DeleteCategoryUseCase{repo: repo}
+}
+
+// Execute はカテゴリ削除ユースケースを実行します。
+func (uc *DeleteCategoryUseCase) Execute(ctx context.Context, userID string, id int) error {
+	count, err := uc.repo.CountExpensesByCategory(ctx, userID, int32(id))
+	if err != nil {
+		return &InternalError{Message: "internal error"}
+	}
+	if count > 0 {
+		return &ValidationError{Message: "このカテゴリは支出で使用されているため削除できません"}
+	}
+
+	return uc.repo.DeleteCategory(ctx, userID, int32(id))
+}

--- a/backend/internal/usecase/delete_category.go
+++ b/backend/internal/usecase/delete_category.go
@@ -2,6 +2,9 @@ package usecase
 
 import (
 	"context"
+	"errors"
+
+	"pace-wallet-backend/internal/domain"
 )
 
 type deleteCategoryRepository interface {
@@ -29,5 +32,11 @@ func (uc *DeleteCategoryUseCase) Execute(ctx context.Context, userID string, id 
 		return &ValidationError{Message: "このカテゴリは支出で使用されているため削除できません"}
 	}
 
-	return uc.repo.DeleteCategory(ctx, userID, int32(id))
+	if err := uc.repo.DeleteCategory(ctx, userID, int32(id)); err != nil {
+		if errors.Is(err, domain.ErrCategoryNotFound) {
+			return &NotFoundError{Message: "カテゴリが見つかりません"}
+		}
+		return &InternalError{Message: "internal error"}
+	}
+	return nil
 }

--- a/backend/internal/usecase/expense_test.go
+++ b/backend/internal/usecase/expense_test.go
@@ -36,7 +36,7 @@ type mockCategoryRepo struct {
 	err    error
 }
 
-func (m *mockCategoryRepo) CategoryExists(ctx context.Context, id int32) (bool, error) {
+func (m *mockCategoryRepo) CategoryExists(ctx context.Context, userID string, id int32) (bool, error) {
 	if m.err != nil {
 		return false, m.err
 	}

--- a/backend/internal/usecase/list_categories.go
+++ b/backend/internal/usecase/list_categories.go
@@ -7,7 +7,7 @@ import (
 )
 
 type listCategoriesRepository interface {
-	ListCategories(ctx context.Context) ([]domain.Category, error)
+	ListCategories(ctx context.Context, userID string) ([]domain.Category, error)
 }
 
 // ListCategoriesUseCase はカテゴリ一覧取得ユースケースです。
@@ -21,6 +21,6 @@ func NewListCategoriesUseCase(repo listCategoriesRepository) *ListCategoriesUseC
 }
 
 // Execute はカテゴリ一覧取得ユースケースを実行します。
-func (uc *ListCategoriesUseCase) Execute(ctx context.Context) ([]domain.Category, error) {
-	return uc.repo.ListCategories(ctx)
+func (uc *ListCategoriesUseCase) Execute(ctx context.Context, userID string) ([]domain.Category, error) {
+	return uc.repo.ListCategories(ctx, userID)
 }

--- a/backend/internal/usecase/reorder_categories.go
+++ b/backend/internal/usecase/reorder_categories.go
@@ -1,0 +1,35 @@
+package usecase
+
+import (
+	"context"
+)
+
+type reorderCategoriesRepository interface {
+	UpdateCategorySortOrder(ctx context.Context, userID string, id int32, sortOrder int32) error
+}
+
+// ReorderCategoriesInput は並び替え入力DTOです。
+type ReorderCategoriesInput struct {
+	ID        int `json:"id"`
+	SortOrder int `json:"sort_order"`
+}
+
+// ReorderCategoriesUseCase はカテゴリ並び替えユースケースです。
+type ReorderCategoriesUseCase struct {
+	repo reorderCategoriesRepository
+}
+
+// NewReorderCategoriesUseCase は ReorderCategoriesUseCase の新しいインスタンスを生成します。
+func NewReorderCategoriesUseCase(repo reorderCategoriesRepository) *ReorderCategoriesUseCase {
+	return &ReorderCategoriesUseCase{repo: repo}
+}
+
+// Execute はカテゴリ並び替えユースケースを実行します。
+func (uc *ReorderCategoriesUseCase) Execute(ctx context.Context, userID string, items []ReorderCategoriesInput) error {
+	for _, item := range items {
+		if err := uc.repo.UpdateCategorySortOrder(ctx, userID, int32(item.ID), int32(item.SortOrder)); err != nil {
+			return &InternalError{Message: "internal error"}
+		}
+	}
+	return nil
+}

--- a/backend/internal/usecase/reorder_categories.go
+++ b/backend/internal/usecase/reorder_categories.go
@@ -19,23 +19,36 @@ type ReorderCategoriesInput struct {
 
 // ReorderCategoriesUseCase はカテゴリ並び替えユースケースです。
 type ReorderCategoriesUseCase struct {
-	repo reorderCategoriesRepository
+	repo      reorderCategoriesRepository
+	txManager TxManager
 }
 
 // NewReorderCategoriesUseCase は ReorderCategoriesUseCase の新しいインスタンスを生成します。
-func NewReorderCategoriesUseCase(repo reorderCategoriesRepository) *ReorderCategoriesUseCase {
-	return &ReorderCategoriesUseCase{repo: repo}
+func NewReorderCategoriesUseCase(repo reorderCategoriesRepository, txManager TxManager) *ReorderCategoriesUseCase {
+	return &ReorderCategoriesUseCase{repo: repo, txManager: txManager}
 }
 
 // Execute はカテゴリ並び替えユースケースを実行します。
+// 複数の UPDATE を1トランザクションで実行し、部分更新を防ぎます。
 func (uc *ReorderCategoriesUseCase) Execute(ctx context.Context, userID string, items []ReorderCategoriesInput) error {
+	tx, err := uc.txManager.Begin(ctx)
+	if err != nil {
+		return &InternalError{Message: "internal error"}
+	}
+	txCtx := tx.Context(ctx)
+
 	for _, item := range items {
-		if err := uc.repo.UpdateCategorySortOrder(ctx, userID, int32(item.ID), int32(item.SortOrder)); err != nil {
+		if err := uc.repo.UpdateCategorySortOrder(txCtx, userID, int32(item.ID), int32(item.SortOrder)); err != nil {
+			_ = tx.Rollback()
 			if errors.Is(err, domain.ErrCategoryNotFound) {
 				return &NotFoundError{Message: "カテゴリが見つかりません"}
 			}
 			return &InternalError{Message: "internal error"}
 		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return &InternalError{Message: "internal error"}
 	}
 	return nil
 }

--- a/backend/internal/usecase/reorder_categories.go
+++ b/backend/internal/usecase/reorder_categories.go
@@ -2,6 +2,9 @@ package usecase
 
 import (
 	"context"
+	"errors"
+
+	"pace-wallet-backend/internal/domain"
 )
 
 type reorderCategoriesRepository interface {
@@ -28,6 +31,9 @@ func NewReorderCategoriesUseCase(repo reorderCategoriesRepository) *ReorderCateg
 func (uc *ReorderCategoriesUseCase) Execute(ctx context.Context, userID string, items []ReorderCategoriesInput) error {
 	for _, item := range items {
 		if err := uc.repo.UpdateCategorySortOrder(ctx, userID, int32(item.ID), int32(item.SortOrder)); err != nil {
+			if errors.Is(err, domain.ErrCategoryNotFound) {
+				return &NotFoundError{Message: "カテゴリが見つかりません"}
+			}
 			return &InternalError{Message: "internal error"}
 		}
 	}

--- a/backend/internal/usecase/update_category.go
+++ b/backend/internal/usecase/update_category.go
@@ -35,6 +35,9 @@ func (uc *UpdateCategoryUseCase) Execute(ctx context.Context, userID string, id 
 
 	cat, err := uc.repo.UpdateCategory(ctx, userID, int32(id), name)
 	if err != nil {
+		if errors.Is(err, domain.ErrDuplicateCategoryName) {
+			return domain.Category{}, &ValidationError{Message: "同じ名前のカテゴリがすでに存在します"}
+		}
 		if errors.Is(err, sql.ErrNoRows) {
 			return domain.Category{}, &NotFoundError{Message: "カテゴリが見つかりません"}
 		}

--- a/backend/internal/usecase/update_category.go
+++ b/backend/internal/usecase/update_category.go
@@ -1,0 +1,44 @@
+package usecase
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+
+	"pace-wallet-backend/internal/domain"
+)
+
+type updateCategoryRepository interface {
+	UpdateCategory(ctx context.Context, userID string, id int32, name string) (domain.Category, error)
+}
+
+// UpdateCategoryUseCase はカテゴリ更新ユースケースです。
+type UpdateCategoryUseCase struct {
+	repo updateCategoryRepository
+}
+
+// NewUpdateCategoryUseCase は UpdateCategoryUseCase の新しいインスタンスを生成します。
+func NewUpdateCategoryUseCase(repo updateCategoryRepository) *UpdateCategoryUseCase {
+	return &UpdateCategoryUseCase{repo: repo}
+}
+
+// Execute はカテゴリ更新ユースケースを実行します。
+func (uc *UpdateCategoryUseCase) Execute(ctx context.Context, userID string, id int, name string) (domain.Category, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return domain.Category{}, &ValidationError{Message: "カテゴリ名を入力してください"}
+	}
+	if len([]rune(name)) > CategoryNameMaxLen {
+		return domain.Category{}, &ValidationError{Message: "カテゴリ名は50文字以内で入力してください"}
+	}
+
+	cat, err := uc.repo.UpdateCategory(ctx, userID, int32(id), name)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.Category{}, &NotFoundError{Message: "カテゴリが見つかりません"}
+		}
+		return domain.Category{}, &InternalError{Message: "internal error"}
+	}
+	return cat, nil
+}

--- a/backend/internal/usecase/update_expense.go
+++ b/backend/internal/usecase/update_expense.go
@@ -26,7 +26,7 @@ type updateExpenseRepository interface {
 }
 
 type updateCategoryExistsChecker interface {
-	CategoryExists(ctx context.Context, id int32) (bool, error)
+	CategoryExists(ctx context.Context, userID string, id int32) (bool, error)
 }
 
 // UpdateExpenseUseCase は支出更新ユースケースです。
@@ -96,7 +96,7 @@ func (uc *UpdateExpenseUseCase) Execute(userID string, input UpdateExpenseInput)
 	}
 
 	// カテゴリ存在チェック（現在のExpense取得後に実施）
-	exists, err := uc.category.CategoryExists(context.Background(), int32(*input.CategoryID))
+	exists, err := uc.category.CategoryExists(context.Background(), userID, int32(*input.CategoryID))
 	if err != nil {
 		return domain.Expense{}, &InternalError{Message: "internal error"}
 	}

--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -259,6 +259,18 @@ paths:
       responses:
         "204":
           description: "Reordered successfully"
+        "400":
+          description: "Bad Request"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: "One or more category IDs not found or belong to another user"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         "500":
           description: "Internal Server Error"
           content:
@@ -307,7 +319,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         "404":
-          description: "Not Found"
+          description: "Category not found or belongs to another user"
           content:
             application/json:
               schema:
@@ -333,6 +345,12 @@ paths:
           description: "Deleted successfully"
         "400":
           description: "Bad Request (category is referenced by expenses)"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: "Category not found or belongs to another user"
           content:
             application/json:
               schema:
@@ -445,7 +463,15 @@ components:
           type: string
           enum: [planned, confirmed]
           description: "Expense status. Allowed values are 'planned' or 'confirmed'. Note: Status transition rule on update: 'confirmed' -> 'planned' is prohibited; 'planned' -> 'confirmed' is allowed."
-        catego
+        category:
+          $ref: '#/components/schemas/Category'
+      required:
+        - id
+        - amount
+        - memo
+        - spent_at
+        - status
+        - category
 
     User:
       type: object
@@ -470,15 +496,7 @@ components:
         - income
         - saving_goal
         - created_at
-        - updated_atry:
-          $ref: '#/components/schemas/Category'
-      required:
-        - id
-        - amount
-        - memo
-        - spent_at
-        - status
-        - category
+        - updated_at
 
     Category:
       type: object

--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -190,6 +190,159 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - "categories"
+      summary: "Create a user category"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+              required:
+                - name
+      responses:
+        "201":
+          description: "Category created"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  category:
+                    $ref: '#/components/schemas/Category'
+                required:
+                  - category
+        "400":
+          description: "Bad Request"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: "Internal Server Error"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /categories/reorder:
+    put:
+      tags:
+        - "categories"
+      summary: "Reorder categories"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                items:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                      sort_order:
+                        type: integer
+                    required:
+                      - id
+                      - sort_order
+              required:
+                - items
+      responses:
+        "204":
+          description: "Reordered successfully"
+        "500":
+          description: "Internal Server Error"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /categories/{id}:
+    put:
+      tags:
+        - "categories"
+      summary: "Update a category"
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+              required:
+                - name
+      responses:
+        "200":
+          description: "Category updated"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  category:
+                    $ref: '#/components/schemas/Category'
+                required:
+                  - category
+        "400":
+          description: "Bad Request"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: "Not Found"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: "Internal Server Error"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - "categories"
+      summary: "Delete a category"
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "204":
+          description: "Deleted successfully"
+        "400":
+          description: "Bad Request (category is referenced by expenses)"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: "Internal Server Error"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /user/me:
     get:
@@ -334,9 +487,16 @@ components:
           type: integer
         name:
           type: string
+        category_type:
+          type: string
+          enum: [default, user, other]
+        sort_order:
+          type: integer
       required:
         - id
         - name
+        - category_type
+        - sort_order
 
     CreateExpenseRequest:
       type: object

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -8,4 +8,8 @@ module.exports = {
   transform: {
     ...tsJestTransformCfg,
   },
+  moduleNameMapper: {
+    "^@/lib/firebase/config$": "<rootDir>/src/lib/firebase/__mocks__/config.ts",
+    "^@/(.*)$": "<rootDir>/src/$1",
+  },
 };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "pace-wallet-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "firebase": "^12.9.0",
         "next": "^16.1.6",
         "react": "19.2.3",
@@ -736,6 +738,60 @@
       "peer": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,8 @@
     "test": "jest"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "firebase": "^12.9.0",
     "next": "^16.1.6",
     "react": "19.2.3",

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -2,11 +2,15 @@
 
 import { useState } from 'react'
 import { useFixedCosts } from '@/hooks/useFixedCosts'
+import { useCategories } from '@/hooks/useCategories'
 import { useDashboard } from '@/hooks/useDashboard'
 import { FixedCostList } from '@/components/FixedCostList'
 import { FixedCostForm } from '@/components/FixedCostForm'
+import { CategoryList } from '@/components/CategoryList'
+import { CategoryForm } from '@/components/CategoryForm'
 import { UserForm } from '@/components/UserForm'
 import { FixedCost, FixedCostInput } from '@/lib/types/fixed-cost'
+import { Category, ReorderCategoryItem } from '@/lib/types/category'
 import { UpdateUserInput } from '@/lib/types/user'
 import { Container } from '@/components/Layout/Container'
 import { Button } from '@/components/ui/Button'
@@ -14,9 +18,13 @@ import { Button } from '@/components/ui/Button'
 export default function SettingsPage() {
   const { dashboard, updateUserSettings, isSubmitting: userSubmitting, isLoading: dashboardLoading, error: dashboardError, refetch: refetchDashboard } = useDashboard()
   const { fixedCosts, createFixedCost, updateFixedCost, deleteFixedCost, isSubmitting: fcSubmitting, isLoading: fcLoading, error: fcError } = useFixedCosts()
+  const { categories, createCategory, updateCategory, deleteCategory, reorderCategories, isSubmitting: catSubmitting, isLoading: catLoading, error: catError } = useCategories()
+
   const [editingFixedCost, setEditingFixedCost] = useState<FixedCost | null>(null)
   const [showFixedCostForm, setShowFixedCostForm] = useState(false)
   const [showUserForm, setShowUserForm] = useState(false)
+  const [editingCategory, setEditingCategory] = useState<Category | null>(null)
+  const [showCategoryForm, setShowCategoryForm] = useState(false)
 
   const handleFixedCostEdit = (fixedCost: FixedCost) => {
     setEditingFixedCost(fixedCost)
@@ -25,7 +33,6 @@ export default function SettingsPage() {
 
   const handleFixedCostCreateSubmit = async (input: FixedCostInput) => {
     const success = await createFixedCost(input)
-    // 成功時のみフォーム閉じてダッシュボード再取得
     if (success) {
       setShowFixedCostForm(false)
       refetchDashboard()
@@ -34,9 +41,7 @@ export default function SettingsPage() {
 
   const handleFixedCostUpdateSubmit = async (input: FixedCostInput) => {
     if (!editingFixedCost) return
-    
     const success = await updateFixedCost(editingFixedCost.id, input)
-    // 成功時のみ編集モード解除とダッシュボード再取得
     if (success) {
       setEditingFixedCost(null)
       setShowFixedCostForm(false)
@@ -59,9 +64,7 @@ export default function SettingsPage() {
 
   const handleFixedCostDelete = async (id: number) => {
     if (!confirm('本当に削除しますか？')) return
-    
     const success = await deleteFixedCost(id)
-    // 削除成功時のみダッシュボード再取得と編集モード解除
     if (success) {
       if (editingFixedCost?.id === id) {
         setEditingFixedCost(null)
@@ -73,13 +76,46 @@ export default function SettingsPage() {
 
   const handleUserSubmit = async (input: UpdateUserInput) => {
     const success = await updateUserSettings(input)
-    if (success) {
-      setShowUserForm(false)
+    if (success) setShowUserForm(false)
+  }
+
+  const handleCancelUserEdit = () => setShowUserForm(false)
+
+  // Category handlers
+  const handleCategoryEdit = (category: Category) => {
+    setEditingCategory(category)
+    setShowCategoryForm(true)
+  }
+
+  const handleCategoryFormSubmit = async (name: string) => {
+    if (editingCategory) {
+      const success = await updateCategory(editingCategory.id, { name })
+      if (success) {
+        setEditingCategory(null)
+        setShowCategoryForm(false)
+      }
+    } else {
+      const success = await createCategory({ name })
+      if (success) setShowCategoryForm(false)
     }
   }
 
-  const handleCancelUserEdit = () => {
-    setShowUserForm(false)
+  const handleCancelCategoryEdit = () => {
+    setEditingCategory(null)
+    setShowCategoryForm(false)
+  }
+
+  const handleCategoryDelete = async (id: number) => {
+    if (!confirm('本当に削除しますか？')) return
+    const success = await deleteCategory(id)
+    if (success && editingCategory?.id === id) {
+      setEditingCategory(null)
+      setShowCategoryForm(false)
+    }
+  }
+
+  const handleCategoryReorder = async (items: ReorderCategoryItem[]) => {
+    await reorderCategories(items)
   }
 
   return (
@@ -91,7 +127,7 @@ export default function SettingsPage() {
         <div className="flex justify-between items-center mb-3 sm:mb-4">
           <h2 className="text-base sm:text-lg font-semibold text-foreground">基本情報</h2>
           {!showUserForm && (
-            <Button 
+            <Button
               onClick={() => setShowUserForm(true)}
               disabled={dashboardLoading}
               size="sm"
@@ -128,12 +164,49 @@ export default function SettingsPage() {
         )}
       </section>
 
+      {/* カテゴリセクション */}
+      <section className="bg-card border border-border rounded-lg shadow-sm p-4 sm:p-6">
+        <div className="flex justify-between items-center mb-3 sm:mb-4">
+          <h2 className="text-base sm:text-lg font-semibold text-foreground">カテゴリ</h2>
+          {!showCategoryForm && (
+            <Button
+              onClick={() => { setEditingCategory(null); setShowCategoryForm(true) }}
+              size="sm"
+            >
+              カテゴリを追加
+            </Button>
+          )}
+        </div>
+
+        {showCategoryForm && (
+          <div className="mb-4">
+            <CategoryForm
+              category={editingCategory}
+              onSubmit={handleCategoryFormSubmit}
+              onCancel={handleCancelCategoryEdit}
+              isSubmitting={catSubmitting}
+            />
+          </div>
+        )}
+
+        {catLoading && <p className="text-muted-foreground">読み込み中...</p>}
+        {catError && <p className="text-danger">{catError}</p>}
+
+        <CategoryList
+          categories={categories}
+          onEdit={handleCategoryEdit}
+          onDelete={handleCategoryDelete}
+          onReorder={handleCategoryReorder}
+          isSubmitting={catSubmitting}
+        />
+      </section>
+
       {/* 固定費セクション */}
       <section className="bg-card border border-border rounded-lg shadow-sm p-4 sm:p-6">
         <div className="flex justify-between items-center mb-3 sm:mb-4">
           <h2 className="text-base sm:text-lg font-semibold text-foreground">固定費</h2>
           {!showFixedCostForm && (
-            <Button 
+            <Button
               onClick={() => setShowFixedCostForm(true)}
               size="sm"
             >
@@ -141,10 +214,10 @@ export default function SettingsPage() {
             </Button>
           )}
         </div>
-        
+
         {showFixedCostForm && (
           <div className="mb-4">
-            <FixedCostForm 
+            <FixedCostForm
               fixedCost={editingFixedCost}
               onSubmit={handleFixedCostSubmit}
               onCancel={handleCancelFixedCostEdit}
@@ -156,11 +229,11 @@ export default function SettingsPage() {
         {fcLoading && <p className="text-muted-foreground">読み込み中...</p>}
         {fcError && <p className="text-danger">{fcError}</p>}
 
-        <FixedCostList 
-          fixedCosts={fixedCosts} 
-          onEdit={handleFixedCostEdit} 
-          onDelete={handleFixedCostDelete} 
-          isSubmitting={fcSubmitting} 
+        <FixedCostList
+          fixedCosts={fixedCosts}
+          onEdit={handleFixedCostEdit}
+          onDelete={handleFixedCostDelete}
+          isSubmitting={fcSubmitting}
         />
       </section>
     </Container>

--- a/frontend/src/components/CategoryForm.tsx
+++ b/frontend/src/components/CategoryForm.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { useState, useEffect } from "react";
+import { Category } from "@/lib/types/category";
+
+const CATEGORY_NAME_MAX_LENGTH = 50;
+
+type Props = {
+  category: Category | null;
+  onSubmit: (name: string) => void;
+  onCancel: () => void;
+  isSubmitting: boolean;
+};
+
+export function CategoryForm({ category, onSubmit, onCancel, isSubmitting }: Props) {
+  const [name, setName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setName(category ? category.name : "");
+    setError(null);
+  }, [category]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setError("カテゴリ名を入力してください");
+      return;
+    }
+    if ([...trimmedName].length > CATEGORY_NAME_MAX_LENGTH) {
+      setError(`カテゴリ名は${CATEGORY_NAME_MAX_LENGTH}文字以内で入力してください`);
+      return;
+    }
+
+    onSubmit(trimmedName);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <h3 className="text-base font-semibold text-foreground">
+        {category ? "カテゴリを編集" : "カテゴリを追加"}
+      </h3>
+
+      {error && (
+        <div className="p-3 bg-danger/10 border border-danger rounded-lg text-danger text-sm">
+          {error}
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <label htmlFor="category-name" className="block text-sm font-medium text-foreground">
+          カテゴリ名 <span className="text-danger">*</span>
+        </label>
+        <input
+          id="category-name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          disabled={isSubmitting}
+          className="w-full px-3 py-2 bg-input border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50 disabled:cursor-not-allowed"
+          placeholder="例: 外食費、ジム代"
+          maxLength={CATEGORY_NAME_MAX_LENGTH}
+        />
+      </div>
+
+      <div className="flex gap-2 pt-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isSubmitting}
+          className="px-4 py-2 text-sm font-medium rounded-lg bg-secondary hover:bg-secondary-hover text-secondary-foreground disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          キャンセル
+        </button>
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="px-4 py-2 text-sm font-medium rounded-lg bg-primary hover:bg-primary-hover text-primary-foreground disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {isSubmitting ? "保存中..." : "保存"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/CategoryList.tsx
+++ b/frontend/src/components/CategoryList.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import { Category, ReorderCategoryItem } from "@/lib/types/category";
+
+type Props = {
+  categories: Category[];
+  onEdit: (category: Category) => void;
+  onDelete: (id: number) => void;
+  onReorder: (items: ReorderCategoryItem[]) => void;
+  isSubmitting: boolean;
+};
+
+const GROUP_LABELS: Record<string, string> = {
+  default: "デフォルト",
+  user: "ユーザー定義",
+  other: "その他",
+};
+
+export function CategoryList({ categories, onEdit, onDelete, onReorder, isSubmitting }: Props) {
+  if (categories.length === 0) {
+    return (
+      <div className="text-center py-8 text-muted-foreground">
+        カテゴリが登録されていません
+      </div>
+    );
+  }
+
+  const groups: Array<{ type: string; items: Category[] }> = [
+    { type: "default", items: categories.filter((c) => c.category_type === "default") },
+    { type: "user", items: categories.filter((c) => c.category_type === "user") },
+    { type: "other", items: categories.filter((c) => c.category_type === "other") },
+  ].filter((g) => g.items.length > 0);
+
+  const handleMove = (group: Category[], current: Category, direction: "up" | "down") => {
+    const idx = group.indexOf(current);
+    const swapIdx = direction === "up" ? idx - 1 : idx + 1;
+    if (swapIdx < 0 || swapIdx >= group.length) return;
+
+    const target = group[swapIdx];
+    onReorder([
+      { id: current.id, sort_order: target.sort_order },
+      { id: target.id, sort_order: current.sort_order },
+    ]);
+  };
+
+  return (
+    <div className="space-y-6">
+      {groups.map(({ type, items }) => (
+        <div key={type}>
+          <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2 px-1">
+            {GROUP_LABELS[type]}
+          </div>
+          <ul className="list-none p-0 space-y-2">
+            {items.map((cat, idx) => (
+              <li
+                key={cat.id}
+                className="p-3 border border-border bg-card rounded-lg flex items-center gap-2 shadow-sm"
+              >
+                {/* 並び替えボタン (その他グループは非表示) */}
+                {type !== "other" && (
+                  <div className="flex flex-col gap-0.5 flex-shrink-0">
+                    <button
+                      onClick={() => handleMove(items, cat, "up")}
+                      disabled={isSubmitting || idx === 0}
+                      aria-label="上に移動"
+                      className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                    >
+                      ▲
+                    </button>
+                    <button
+                      onClick={() => handleMove(items, cat, "down")}
+                      disabled={isSubmitting || idx === items.length - 1}
+                      aria-label="下に移動"
+                      className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                    >
+                      ▼
+                    </button>
+                  </div>
+                )}
+
+                <span className="flex-1 text-sm font-medium text-foreground">{cat.name}</span>
+
+                <div className="flex gap-2 flex-shrink-0">
+                  <button
+                    onClick={() => onEdit(cat)}
+                    disabled={isSubmitting}
+                    className="px-3 py-1.5 text-xs font-medium rounded bg-primary hover:bg-primary-hover text-primary-foreground disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+                  >
+                    編集
+                  </button>
+                  <button
+                    onClick={() => onDelete(cat.id)}
+                    disabled={isSubmitting}
+                    className="px-3 py-1.5 text-xs font-medium rounded bg-danger hover:bg-danger-hover text-danger-foreground disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+                  >
+                    削除
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/CategoryList.tsx
+++ b/frontend/src/components/CategoryList.tsx
@@ -10,12 +10,6 @@ type Props = {
   isSubmitting: boolean;
 };
 
-const GROUP_LABELS: Record<string, string> = {
-  default: "デフォルト",
-  user: "ユーザー定義",
-  other: "その他",
-};
-
 export function CategoryList({ categories, onEdit, onDelete, onReorder, isSubmitting }: Props) {
   if (categories.length === 0) {
     return (
@@ -25,82 +19,77 @@ export function CategoryList({ categories, onEdit, onDelete, onReorder, isSubmit
     );
   }
 
-  const groups: Array<{ type: string; items: Category[] }> = [
-    { type: "default", items: categories.filter((c) => c.category_type === "default") },
-    { type: "user", items: categories.filter((c) => c.category_type === "user") },
-    { type: "other", items: categories.filter((c) => c.category_type === "other") },
-  ].filter((g) => g.items.length > 0);
+  // 'other' は常に末尾に固定表示。それ以外は sort_order 順に統合表示
+  const mainCategories = categories.filter((c) => c.category_type !== "other");
+  const otherCategories = categories.filter((c) => c.category_type === "other");
 
-  const handleMove = (group: Category[], current: Category, direction: "up" | "down") => {
-    const idx = group.indexOf(current);
+  const handleMove = (list: Category[], current: Category, direction: "up" | "down") => {
+    const idx = list.indexOf(current);
     const swapIdx = direction === "up" ? idx - 1 : idx + 1;
-    if (swapIdx < 0 || swapIdx >= group.length) return;
+    if (swapIdx < 0 || swapIdx >= list.length) return;
 
-    const target = group[swapIdx];
+    const target = list[swapIdx];
     onReorder([
       { id: current.id, sort_order: target.sort_order },
       { id: target.id, sort_order: current.sort_order },
     ]);
   };
 
-  return (
-    <div className="space-y-6">
-      {groups.map(({ type, items }) => (
-        <div key={type}>
-          <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2 px-1">
-            {GROUP_LABELS[type]}
-          </div>
-          <ul className="list-none p-0 space-y-2">
-            {items.map((cat, idx) => (
-              <li
-                key={cat.id}
-                className="p-3 border border-border bg-card rounded-lg flex items-center gap-2 shadow-sm"
-              >
-                {/* 並び替えボタン (その他グループは非表示) */}
-                {type !== "other" && (
-                  <div className="flex flex-col gap-0.5 flex-shrink-0">
-                    <button
-                      onClick={() => handleMove(items, cat, "up")}
-                      disabled={isSubmitting || idx === 0}
-                      aria-label="上に移動"
-                      className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-                    >
-                      ▲
-                    </button>
-                    <button
-                      onClick={() => handleMove(items, cat, "down")}
-                      disabled={isSubmitting || idx === items.length - 1}
-                      aria-label="下に移動"
-                      className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-                    >
-                      ▼
-                    </button>
-                  </div>
-                )}
-
-                <span className="flex-1 text-sm font-medium text-foreground">{cat.name}</span>
-
-                <div className="flex gap-2 flex-shrink-0">
-                  <button
-                    onClick={() => onEdit(cat)}
-                    disabled={isSubmitting}
-                    className="px-3 py-1.5 text-xs font-medium rounded bg-primary hover:bg-primary-hover text-primary-foreground disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
-                  >
-                    編集
-                  </button>
-                  <button
-                    onClick={() => onDelete(cat.id)}
-                    disabled={isSubmitting}
-                    className="px-3 py-1.5 text-xs font-medium rounded bg-danger hover:bg-danger-hover text-danger-foreground disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
-                  >
-                    削除
-                  </button>
-                </div>
-              </li>
-            ))}
-          </ul>
+  const renderItem = (cat: Category, idx: number, list: Category[], showMoveButtons: boolean) => (
+    <li
+      key={cat.id}
+      className="p-3 border border-border bg-card rounded-lg flex items-center gap-2 shadow-sm"
+    >
+      {showMoveButtons && (
+        <div className="flex flex-col gap-0.5 flex-shrink-0">
+          <button
+            onClick={() => handleMove(list, cat, "up")}
+            disabled={isSubmitting || idx === 0}
+            aria-label="上に移動"
+            className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          >
+            ▲
+          </button>
+          <button
+            onClick={() => handleMove(list, cat, "down")}
+            disabled={isSubmitting || idx === list.length - 1}
+            aria-label="下に移動"
+            className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          >
+            ▼
+          </button>
         </div>
-      ))}
-    </div>
+      )}
+
+      <span className="flex-1 text-sm font-medium text-foreground">{cat.name}</span>
+
+      <div className="flex gap-2 flex-shrink-0">
+        <button
+          onClick={() => onEdit(cat)}
+          disabled={isSubmitting}
+          className="px-3 py-1.5 text-xs font-medium rounded bg-primary hover:bg-primary-hover text-primary-foreground disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+        >
+          編集
+        </button>
+        <button
+          onClick={() => onDelete(cat.id)}
+          disabled={isSubmitting}
+          className="px-3 py-1.5 text-xs font-medium rounded bg-danger hover:bg-danger-hover text-danger-foreground disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+        >
+          削除
+        </button>
+      </div>
+    </li>
+  );
+
+  return (
+    <ul className="list-none p-0 space-y-2">
+      {mainCategories.map((cat, idx) =>
+        renderItem(cat, idx, mainCategories, true)
+      )}
+      {otherCategories.map((cat) =>
+        renderItem(cat, 0, otherCategories, false)
+      )}
+    </ul>
   );
 }

--- a/frontend/src/components/CategoryList.tsx
+++ b/frontend/src/components/CategoryList.tsx
@@ -1,65 +1,79 @@
 'use client'
 
-import { Category, ReorderCategoryItem } from "@/lib/types/category";
+import {
+  DndContext,
+  closestCenter,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+
+import { Category, ReorderCategoryItem } from "@/lib/types/category"
 
 type Props = {
-  categories: Category[];
-  onEdit: (category: Category) => void;
-  onDelete: (id: number) => void;
-  onReorder: (items: ReorderCategoryItem[]) => void;
-  isSubmitting: boolean;
-};
+  categories: Category[]
+  onEdit: (category: Category) => void
+  onDelete: (id: number) => void
+  onReorder: (items: ReorderCategoryItem[]) => void
+  isSubmitting: boolean
+}
 
-export function CategoryList({ categories, onEdit, onDelete, onReorder, isSubmitting }: Props) {
-  if (categories.length === 0) {
-    return (
-      <div className="text-center py-8 text-muted-foreground">
-        カテゴリが登録されていません
-      </div>
-    );
+type ItemProps = {
+  cat: Category
+  isSubmitting: boolean
+  onEdit: (category: Category) => void
+  onDelete: (id: number) => void
+}
+
+function SortableCategoryItem({ cat, isSubmitting, onEdit, onDelete }: ItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: cat.id })
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    zIndex: isDragging ? 10 : undefined,
   }
 
-  // 'other' は常に末尾に固定表示。それ以外は sort_order 順に統合表示
-  const mainCategories = categories.filter((c) => c.category_type !== "other");
-  const otherCategories = categories.filter((c) => c.category_type === "other");
-
-  const handleMove = (list: Category[], current: Category, direction: "up" | "down") => {
-    const idx = list.indexOf(current);
-    const swapIdx = direction === "up" ? idx - 1 : idx + 1;
-    if (swapIdx < 0 || swapIdx >= list.length) return;
-
-    const target = list[swapIdx];
-    onReorder([
-      { id: current.id, sort_order: target.sort_order },
-      { id: target.id, sort_order: current.sort_order },
-    ]);
-  };
-
-  const renderItem = (cat: Category, idx: number, list: Category[], showMoveButtons: boolean) => (
+  return (
     <li
-      key={cat.id}
+      ref={setNodeRef}
+      style={style}
       className="p-3 border border-border bg-card rounded-lg flex items-center gap-2 shadow-sm"
     >
-      {showMoveButtons && (
-        <div className="flex flex-col gap-0.5 flex-shrink-0">
-          <button
-            onClick={() => handleMove(list, cat, "up")}
-            disabled={isSubmitting || idx === 0}
-            aria-label="上に移動"
-            className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-          >
-            ▲
-          </button>
-          <button
-            onClick={() => handleMove(list, cat, "down")}
-            disabled={isSubmitting || idx === list.length - 1}
-            aria-label="下に移動"
-            className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-          >
-            ▼
-          </button>
-        </div>
-      )}
+      {/* ドラッグハンドル */}
+      <button
+        {...attributes}
+        {...listeners}
+        disabled={isSubmitting}
+        aria-label="ドラッグして並び替え"
+        className="p-2 -ml-1 flex-shrink-0 text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed touch-manipulation cursor-grab active:cursor-grabbing rounded"
+      >
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <circle cx="5.5" cy="3.5" r="1.25"/>
+          <circle cx="10.5" cy="3.5" r="1.25"/>
+          <circle cx="5.5" cy="8" r="1.25"/>
+          <circle cx="10.5" cy="8" r="1.25"/>
+          <circle cx="5.5" cy="12.5" r="1.25"/>
+          <circle cx="10.5" cy="12.5" r="1.25"/>
+        </svg>
+      </button>
 
       <span className="flex-1 text-sm font-medium text-foreground">{cat.name}</span>
 
@@ -80,16 +94,103 @@ export function CategoryList({ categories, onEdit, onDelete, onReorder, isSubmit
         </button>
       </div>
     </li>
-  );
+  )
+}
+
+function StaticCategoryItem({ cat, isSubmitting, onEdit, onDelete }: ItemProps) {
+  return (
+    <li className="p-3 border border-border bg-card rounded-lg flex items-center gap-2 shadow-sm opacity-70">
+      {/* 並び替え不可のプレースホルダー（ハンドルなし） */}
+      <div className="w-8 flex-shrink-0" />
+
+      <span className="flex-1 text-sm font-medium text-foreground">{cat.name}</span>
+
+      <div className="flex gap-2 flex-shrink-0">
+        <button
+          onClick={() => onEdit(cat)}
+          disabled={isSubmitting}
+          className="px-3 py-1.5 text-xs font-medium rounded bg-primary hover:bg-primary-hover text-primary-foreground disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+        >
+          編集
+        </button>
+        <button
+          onClick={() => onDelete(cat.id)}
+          disabled={isSubmitting}
+          className="px-3 py-1.5 text-xs font-medium rounded bg-danger hover:bg-danger-hover text-danger-foreground disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+        >
+          削除
+        </button>
+      </div>
+    </li>
+  )
+}
+
+export function CategoryList({ categories, onEdit, onDelete, onReorder, isSubmitting }: Props) {
+  // スクロールと誤操作を区別するための activationConstraint
+  const sensors = useSensors(
+    useSensor(MouseSensor, {
+      activationConstraint: { distance: 5 },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 250, tolerance: 5 },
+    })
+  )
+
+  if (categories.length === 0) {
+    return (
+      <div className="text-center py-8 text-muted-foreground">
+        カテゴリが登録されていません
+      </div>
+    )
+  }
+
+  const mainCategories = categories.filter((c) => c.category_type !== "other")
+  const otherCategories = categories.filter((c) => c.category_type === "other")
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+
+    const oldIndex = mainCategories.findIndex((c) => c.id === active.id)
+    const newIndex = mainCategories.findIndex((c) => c.id === over.id)
+    if (oldIndex === -1 || newIndex === -1) return
+
+    const reordered = arrayMove(mainCategories, oldIndex, newIndex)
+    onReorder(reordered.map((c, i) => ({ id: c.id, sort_order: i + 1 })))
+  }
 
   return (
     <ul className="list-none p-0 space-y-2">
-      {mainCategories.map((cat, idx) =>
-        renderItem(cat, idx, mainCategories, true)
-      )}
-      {otherCategories.map((cat) =>
-        renderItem(cat, 0, otherCategories, false)
-      )}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={mainCategories.map((c) => c.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          {mainCategories.map((cat) => (
+            <SortableCategoryItem
+              key={cat.id}
+              cat={cat}
+              isSubmitting={isSubmitting}
+              onEdit={onEdit}
+              onDelete={onDelete}
+            />
+          ))}
+        </SortableContext>
+      </DndContext>
+
+      {otherCategories.map((cat) => (
+        <StaticCategoryItem
+          key={cat.id}
+          cat={cat}
+          isSubmitting={isSubmitting}
+          onEdit={onEdit}
+          onDelete={onDelete}
+        />
+      ))}
     </ul>
-  );
+  )
 }

--- a/frontend/src/components/ExpenseForm.tsx
+++ b/frontend/src/components/ExpenseForm.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 export function ExpenseForm({ mode = 'create', initialData, onSubmit, onCancel, isSubmitting }: Props) {
     const [amount, setAmount] = useState(initialData?.amount.toString() || '')
-    const [categoryId, setCategoryId] = useState(initialData?.category.id.toString() || '1')
+    const [categoryId, setCategoryId] = useState(initialData?.category.id.toString() || '')
     const [memo, setMemo] = useState(initialData?.memo || '')
     const [spentAt, setSpentAt] = useState(initialData?.spent_at || '')
     const [status, setStatus] = useState<'planned' | 'confirmed'>(initialData?.status || 'confirmed')
@@ -23,9 +23,14 @@ export function ExpenseForm({ mode = 'create', initialData, onSubmit, onCancel, 
 
     useEffect(() => {
         getCategories()
-            .then(setCategories)
+            .then((data) => {
+                setCategories(data)
+                if (!initialData && data.length > 0) {
+                    setCategoryId(data[0].id.toString())
+                }
+            })
             .catch(console.error)
-    }, [])
+    }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
     // initialDataが変更されたらフォーム状態を更新（編集対象切り替え時）
     useEffect(() => {
@@ -84,7 +89,7 @@ export function ExpenseForm({ mode = 'create', initialData, onSubmit, onCancel, 
         // 作成モードの時のみリセット（statusは保持）
         if (mode === 'create') {
             setAmount('')
-            setCategoryId('1')
+            setCategoryId(categories.length > 0 ? categories[0].id.toString() : '')
             setMemo('')
             setSpentAt('')
             setErrors({})

--- a/frontend/src/hooks/useCategories.ts
+++ b/frontend/src/hooks/useCategories.ts
@@ -1,0 +1,122 @@
+import { useEffect, useState } from "react";
+import {
+  getCategories,
+  createCategory,
+  updateCategory,
+  deleteCategory,
+  reorderCategories,
+} from "@/lib/api/categories";
+import { Category, CreateCategoryInput, UpdateCategoryInput, ReorderCategoryItem } from "@/lib/types/category";
+
+export function useCategories() {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // GET
+  useEffect(() => {
+    const fetchCategories = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const data = await getCategories();
+        setCategories(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "エラーが発生しました");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchCategories();
+  }, []);
+
+  const refetchCategories = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await getCategories();
+      setCategories(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "エラーが発生しました");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // POST
+  const handleCreateCategory = async (input: CreateCategoryInput): Promise<boolean> => {
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const newCategory = await createCategory(input);
+      setCategories((prev) => [...prev, newCategory]);
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "エラーが発生しました");
+      return false;
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // PUT
+  const handleUpdateCategory = async (id: number, input: UpdateCategoryInput): Promise<boolean> => {
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const updated = await updateCategory(id, input);
+      setCategories((prev) => prev.map((c) => (c.id === id ? updated : c)));
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "エラーが発生しました");
+      return false;
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // DELETE
+  const handleDeleteCategory = async (id: number): Promise<boolean> => {
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await deleteCategory(id);
+      setCategories((prev) => prev.filter((c) => c.id !== id));
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "エラーが発生しました");
+      return false;
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // REORDER
+  const handleReorderCategories = async (items: ReorderCategoryItem[]): Promise<boolean> => {
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await reorderCategories(items);
+      await refetchCategories();
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "エラーが発生しました");
+      return false;
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return {
+    categories,
+    isLoading,
+    isSubmitting,
+    error,
+    createCategory: handleCreateCategory,
+    updateCategory: handleUpdateCategory,
+    deleteCategory: handleDeleteCategory,
+    reorderCategories: handleReorderCategories,
+    refetch: refetchCategories,
+  };
+}

--- a/frontend/src/lib/api/categories.test.ts
+++ b/frontend/src/lib/api/categories.test.ts
@@ -1,0 +1,234 @@
+import {
+  getCategories,
+  createCategory,
+  updateCategory,
+  deleteCategory,
+  reorderCategories,
+} from "./categories";
+import { Category, CreateCategoryInput, UpdateCategoryInput, ReorderCategoryItem } from "../types/category";
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  (global as any).fetch = jest.fn();
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+const API_BASE = "http://localhost:8080";
+
+const sampleCategory: Category = {
+  id: 1,
+  name: "食費",
+  category_type: "default",
+  sort_order: 1,
+};
+
+// ---------------------------------------------------------------------------
+// getCategories
+// ---------------------------------------------------------------------------
+describe("getCategories", () => {
+  it("calls fetch with correct URL and method and returns categories on success", async () => {
+    (global as any).fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ categories: [sampleCategory] }),
+    });
+
+    const result = await getCategories();
+
+    expect((global as any).fetch).toHaveBeenCalledTimes(1);
+    expect((global as any).fetch).toHaveBeenCalledWith(
+      `${API_BASE}/categories`,
+      expect.objectContaining({ method: "GET" })
+    );
+    expect(result).toEqual([sampleCategory]);
+  });
+
+  it("throws Error when response.ok is false", async () => {
+    (global as any).fetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => { throw new Error("not json"); },
+    });
+
+    await expect(getCategories()).rejects.toThrow("カテゴリの取得に失敗しました");
+  });
+
+  it("throws Error when response body is not a valid categories array", async () => {
+    (global as any).fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ categories: null }),
+    });
+
+    await expect(getCategories()).rejects.toThrow("カテゴリのレスポンスが正しくありません");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createCategory
+// ---------------------------------------------------------------------------
+describe("createCategory", () => {
+  const input: CreateCategoryInput = { name: "外食" };
+
+  it("calls fetch with correct URL, method, headers, and body and returns category on success", async () => {
+    (global as any).fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ category: { ...sampleCategory, name: "外食" } }),
+    });
+
+    const result = await createCategory(input);
+
+    expect((global as any).fetch).toHaveBeenCalledTimes(1);
+    expect((global as any).fetch).toHaveBeenCalledWith(
+      `${API_BASE}/categories`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      }
+    );
+    expect(result.name).toBe("外食");
+  });
+
+  it("throws Error when response.ok is false", async () => {
+    (global as any).fetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => { throw new Error("not json"); },
+    });
+
+    await expect(createCategory(input)).rejects.toThrow("カテゴリの作成に失敗しました");
+  });
+
+  it("surfaces server error message from JSON body", async () => {
+    (global as any).fetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: "同じ名前のカテゴリがすでに存在します" }),
+    });
+
+    await expect(createCategory(input)).rejects.toThrow("同じ名前のカテゴリがすでに存在します");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateCategory
+// ---------------------------------------------------------------------------
+describe("updateCategory", () => {
+  const input: UpdateCategoryInput = { name: "外食費" };
+
+  it("calls fetch with correct URL, method, headers, and body and returns category on success", async () => {
+    (global as any).fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ category: { ...sampleCategory, name: "外食費" } }),
+    });
+
+    const result = await updateCategory(1, input);
+
+    expect((global as any).fetch).toHaveBeenCalledTimes(1);
+    expect((global as any).fetch).toHaveBeenCalledWith(
+      `${API_BASE}/categories/1`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      }
+    );
+    expect(result.name).toBe("外食費");
+  });
+
+  it("throws Error when response.ok is false", async () => {
+    (global as any).fetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => { throw new Error("not json"); },
+    });
+
+    await expect(updateCategory(1, input)).rejects.toThrow("カテゴリの更新に失敗しました");
+  });
+
+  it("surfaces server error message from JSON body", async () => {
+    (global as any).fetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: "同じ名前のカテゴリがすでに存在します" }),
+    });
+
+    await expect(updateCategory(1, input)).rejects.toThrow("同じ名前のカテゴリがすでに存在します");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteCategory
+// ---------------------------------------------------------------------------
+describe("deleteCategory", () => {
+  it("calls fetch with correct URL and method and resolves on success", async () => {
+    (global as any).fetch.mockResolvedValue({ ok: true });
+
+    await expect(deleteCategory(1)).resolves.toBeUndefined();
+
+    expect((global as any).fetch).toHaveBeenCalledTimes(1);
+    expect((global as any).fetch).toHaveBeenCalledWith(
+      `${API_BASE}/categories/1`,
+      expect.objectContaining({ method: "DELETE" })
+    );
+  });
+
+  it("throws Error when response.ok is false", async () => {
+    (global as any).fetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => { throw new Error("not json"); },
+    });
+
+    await expect(deleteCategory(1)).rejects.toThrow("カテゴリの削除に失敗しました");
+  });
+
+  it("surfaces server error message from JSON body", async () => {
+    (global as any).fetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: "このカテゴリは支出で使用されているため削除できません" }),
+    });
+
+    await expect(deleteCategory(1)).rejects.toThrow("このカテゴリは支出で使用されているため削除できません");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reorderCategories
+// ---------------------------------------------------------------------------
+describe("reorderCategories", () => {
+  const items: ReorderCategoryItem[] = [
+    { id: 1, sort_order: 2 },
+    { id: 2, sort_order: 1 },
+  ];
+
+  it("calls fetch with correct URL, method, headers, and body and resolves on success", async () => {
+    (global as any).fetch.mockResolvedValue({ ok: true });
+
+    await expect(reorderCategories(items)).resolves.toBeUndefined();
+
+    expect((global as any).fetch).toHaveBeenCalledTimes(1);
+    expect((global as any).fetch).toHaveBeenCalledWith(
+      `${API_BASE}/categories/reorder`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ items }),
+      }
+    );
+  });
+
+  it("throws Error when response.ok is false", async () => {
+    (global as any).fetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => { throw new Error("not json"); },
+    });
+
+    await expect(reorderCategories(items)).rejects.toThrow("カテゴリの並び替えに失敗しました");
+  });
+});

--- a/frontend/src/lib/api/categories.ts
+++ b/frontend/src/lib/api/categories.ts
@@ -1,4 +1,4 @@
-import { Category } from "@/lib/types/category";
+import { Category, CreateCategoryInput, UpdateCategoryInput, ReorderCategoryItem } from "@/lib/types/category";
 import { API_BASE_URL, getAuthHeaders, handleApiError } from "./client";
 
 export async function getCategories(): Promise<Category[]> {
@@ -14,11 +14,66 @@ export async function getCategories(): Promise<Category[]> {
 
   const data = await res.json()
   if (!data || !Array.isArray(data.categories)) {
-    // 開発者向けログ: 詳細なレスポンス内容を出力
     console.error('[Dev] カテゴリのレスポンスが正しくありません', { data })
-    // ユーザー向けエラー: 固定文言のみ
     throw new Error('カテゴリのレスポンスが正しくありません')
   }
 
   return data.categories
+}
+
+export async function createCategory(input: CreateCategoryInput): Promise<Category> {
+  const headers = await getAuthHeaders();
+  const res = await fetch(`${API_BASE_URL}/categories`, {
+    method: "POST",
+    headers: { ...headers, "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  })
+
+  if (!res.ok) {
+    await handleApiError(res, "カテゴリの作成");
+  }
+
+  const data = await res.json()
+  return data.category
+}
+
+export async function updateCategory(id: number, input: UpdateCategoryInput): Promise<Category> {
+  const headers = await getAuthHeaders();
+  const res = await fetch(`${API_BASE_URL}/categories/${id}`, {
+    method: "PUT",
+    headers: { ...headers, "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  })
+
+  if (!res.ok) {
+    await handleApiError(res, "カテゴリの更新");
+  }
+
+  const data = await res.json()
+  return data.category
+}
+
+export async function deleteCategory(id: number): Promise<void> {
+  const headers = await getAuthHeaders();
+  const res = await fetch(`${API_BASE_URL}/categories/${id}`, {
+    method: "DELETE",
+    headers,
+  })
+
+  if (!res.ok) {
+    await handleApiError(res, "カテゴリの削除");
+  }
+}
+
+export async function reorderCategories(items: ReorderCategoryItem[]): Promise<void> {
+  const headers = await getAuthHeaders();
+  const res = await fetch(`${API_BASE_URL}/categories/reorder`, {
+    method: "PUT",
+    headers: { ...headers, "Content-Type": "application/json" },
+    body: JSON.stringify({ items }),
+  })
+
+  if (!res.ok) {
+    await handleApiError(res, "カテゴリの並び替え");
+  }
 }

--- a/frontend/src/lib/api/expenses.test.ts
+++ b/frontend/src/lib/api/expenses.test.ts
@@ -30,6 +30,7 @@ describe("createExpense", () => {
       category: { id: 3, name: "交通費" },
       memo: "通勤",
       spent_at: "2025-12-31",
+      status: "confirmed",
     };
 
     (global as any).fetch.mockResolvedValue({

--- a/frontend/src/lib/firebase/__mocks__/config.ts
+++ b/frontend/src/lib/firebase/__mocks__/config.ts
@@ -1,0 +1,5 @@
+// Mock for Firebase config used in Jest tests.
+// auth.currentUser is null so getAuthHeaders returns no Authorization header.
+export const auth = {
+  currentUser: null,
+};

--- a/frontend/src/lib/types/category.ts
+++ b/frontend/src/lib/types/category.ts
@@ -1,4 +1,19 @@
 export type Category = {
   id: number
   name: string
+  category_type: 'default' | 'user' | 'other'
+  sort_order: number
+}
+
+export type CreateCategoryInput = {
+  name: string
+}
+
+export type UpdateCategoryInput = {
+  name: string
+}
+
+export type ReorderCategoryItem = {
+  id: number
+  sort_order: number
 }


### PR DESCRIPTION
- closes: #108 

 ## 概要                                                                                                     
      
  カテゴリをユーザーごとに管理できるようにしました。これまでは全ユーザー共通の固定カテゴリでしたが、各ユー 
  ザーが独自のカテゴリを作成・編集・削除・並び替えできるようになります。                                   
   
  - デフォルトカテゴリ（食費・交通費など）はユーザー登録時に自動で付与され、編集・削除も可能               
  - ユーザー独自のカテゴリも追加可能                                                                     
  - 「その他」は常に末尾に固定表示                                                                         
  - 設定画面でカテゴリの表示順を ▲▼ ボタンで並び替え可能（デフォルト・ユーザー定義をまたいだ並び替えも可）
                                                                                                           
  ## 変更内容                                                                                               
                                                                                                           
  ### Backend                                                                                                

  - DBスキーマ (db/schema/user_categories.sql): user_categories テーブルを新規作成。category_type（default 
  / user / other）と sort_order カラムを持つ
  - sqlcクエリ (db/query/categories.sql): 旧クエリを全て user_categories                                   
  ベースに置き換え。並び替え・削除チェック・デフォルトシード用クエリを追加                                 
  - ドメイン/リポジトリ (internal/domain/category.go, infra/repository/): CategoryType, SortOrder
  フィールド追加。CRUD + Seed + Reorder メソッドを実装                                                     
  - ユースケース: CreateCategory, UpdateCategory, DeleteCategory（参照中削除不可）, ReorderCategories    
  を新規追加。CompleteInitialSetup で新規ユーザー作成時にデフォルトカテゴリをシード                        
  - ハンドラー/ルーティング: POST /categories, PUT /categories/reorder, PUT /categories/:id, DELETE      
  /categories/:id を追加（/categories/reorder は /:id より先に登録）                                       
  - マイグレーション (db/migration/001_user_categories.sql):                                             
  既存ユーザーのカテゴリデータを移行するSQLを追加                                                          
                                                                                                         
  ### Frontend                                                                                                 
                                                                                                         
  - 型 (lib/types/category.ts): category_type, sort_order を追加
  - APIクライアント (lib/api/categories.ts): create/update/delete/reorder 関数を追加
  - フック (hooks/useCategories.ts): CRUD + 並び替え操作をまとめたカスタムフックを新規作成                 
  - コンポーネント: CategoryForm.tsx（作成/編集フォーム）、CategoryList.tsx（統合リスト表示 +              
  ▲▼並び替え）を新規作成                                                                                   
  - 設定ページ (app/settings/page.tsx): カテゴリセクションを追加                                           
  - ExpenseForm (components/ExpenseForm.tsx): デフォルト選択値をAPIから取得した先頭カテゴリに変更          
                                                                                                           
 ## マイグレーション手順
                                                                                                           
  本番DBへの適用は backend/db/migration/001_user_categories.sql を実行してください。Step 3 と Step 4 の間に
   NULL チェックを行うことを推奨します。
                                                                                                           
  -- マッピング漏れがないことを確認                                                                        
  SELECT COUNT(*) FROM expenses WHERE new_category_id IS NULL;
                                                                                                           
##  テスト確認項目                                                                                         
                                                                                                           
  - GET /categories がユーザーごとに異なるカテゴリ一覧を返す（表示順：sort_order昇順、その他は末尾）       
  - POST /categories でユーザー定義カテゴリを作成でき、他ユーザーには見えない
  - PUT /categories/:id で他ユーザーのカテゴリは更新できない（404）                                        
  - DELETE /categories/:id で支出が参照中のカテゴリは削除できない（400エラー）                             
  - PUT /categories/reorder で並び替えが反映される                                                         
  - 初期設定完了時にデフォルトカテゴリ7件（食費〜その他）が自動生成される                                  
  - 設定画面でカテゴリのCRUD・並び替えが完結する                                                           
  - マイグレーション後、既存の支出にカテゴリ名が正しく表示される   