### PR TITLE
#113 pre-commitフックとGitHub Actions CIを追加する

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+
+# Detect which directories have staged changes
+STAGED_FILES=$(git diff --cached --name-only)
+
+run_backend=false
+run_frontend=false
+
+if echo "$STAGED_FILES" | grep -q "^backend/"; then
+  run_backend=true
+fi
+if echo "$STAGED_FILES" | grep -q "^frontend/"; then
+  run_frontend=true
+fi
+
+# --- Backend checks ---
+if [ "$run_backend" = true ]; then
+  echo "[pre-commit] Running backend checks..."
+  cd "$ROOT/backend"
+
+  echo "  go build ./..."
+  go build ./...
+
+  echo "  go vet ./..."
+  go vet ./...
+
+  echo "[pre-commit] Backend checks passed."
+  cd "$ROOT"
+fi
+
+# --- Frontend checks ---
+if [ "$run_frontend" = true ]; then
+  echo "[pre-commit] Running frontend checks..."
+  cd "$ROOT/frontend"
+
+  echo "  npm run lint"
+  npm run lint
+
+  echo "  tsc --noEmit"
+  npx tsc --noEmit
+
+  echo "[pre-commit] Frontend checks passed."
+  cd "$ROOT"
+fi
+
+echo "[pre-commit] All checks passed."

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1,0 +1,43 @@
+name: CI - Backend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "backend/**"
+
+jobs:
+  test:
+    name: Go lint & test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: Verify go.mod is tidy
+        working-directory: backend
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+
+      - name: Build
+        working-directory: backend
+        run: go build ./...
+
+      - name: Vet
+        working-directory: backend
+        run: go vet ./...
+
+      - name: Test
+        working-directory: backend
+        run: go test ./...

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -1,0 +1,46 @@
+name: CI - Frontend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "frontend/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "frontend/**"
+
+jobs:
+  test:
+    name: Lint, typecheck & test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Lint
+        working-directory: frontend
+        run: npm run lint
+
+      - name: Typecheck
+        working-directory: frontend
+        run: npx tsc --noEmit
+
+      - name: Test
+        working-directory: frontend
+        run: npm test -- --passWithNoTests
+
+      - name: Build
+        working-directory: frontend
+        run: npm run build

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Configure git to use the project's hooks directory.
+set -euo pipefail
+
+git config core.hooksPath .githooks
+echo "Git hooks configured: .githooks"


### PR DESCRIPTION
## Summary

- `backend/**` の変更時に `go build` / `go vet` / `go test` を実行する GitHub Actions ワークフローを追加 (`.github/workflows/ci-backend.yml`)
- `frontend/**` の変更時に `eslint` / `tsc --noEmit` / `jest` / `next build` を実行する GitHub Actions ワークフローを追加 (`.github/workflows/ci-frontend.yml`)
- コミット時にステージされたファイルのパスを判定し、backend/frontend それぞれのチェックを実行する pre-commit フックを追加 (`.githooks/pre-commit`)
- フックを有効化するセットアップスクリプトを追加 (`scripts/setup-hooks.sh`)

## セットアップ

クローン後に以下を実行してください:

```bash
bash scripts/setup-hooks.sh
```

## Test plan

- [ ] backend のファイルをステージして `git commit` → `go build` / `go vet` が実行されることを確認
- [ ] frontend のファイルをステージして `git commit` → `eslint` / `tsc` が実行されることを確認
- [ ] PR を作成して GitHub Actions が起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)