### PR TITLE
#95 金額入力フィールドに電卓ポップオーバー機能を追加する

### DIFF
--- a/frontend/src/components/ExpenseForm.tsx
+++ b/frontend/src/components/ExpenseForm.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { CreateExpenseInput, UpdateExpenseInput, Expense } from '@/lib/types/expense'
 import { getCategories } from '@/lib/api/categories'
 import { Category } from '@/lib/types/category'
+import { AmountInput } from '@/components/ui/AmountInput'
 
 type Props = {
     mode?: 'create' | 'edit'
@@ -102,11 +103,10 @@ export function ExpenseForm({ mode = 'create', initialData, onSubmit, onCancel, 
             <div className="space-y-2">
                 <label className="block text-xs sm:text-sm font-medium text-foreground">
                     金額
-                    <input
-                        className="mt-1 block w-full px-3 py-2 bg-input border border-border rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
-                        type="number"
+                    <AmountInput
                         value={amount}
-                        onChange={(e) => setAmount(e.target.value)}
+                        onChange={setAmount}
+                        className="mt-1 w-full"
                     />
                 </label>
                 {errors.amount && <p className="text-xs sm:text-sm text-danger">{errors.amount}</p>}

--- a/frontend/src/components/ExpenseForm.tsx
+++ b/frontend/src/components/ExpenseForm.tsx
@@ -106,6 +106,7 @@ export function ExpenseForm({ mode = 'create', initialData, onSubmit, onCancel, 
                     <AmountInput
                         value={amount}
                         onChange={setAmount}
+                        disabled={isSubmitting}
                         className="mt-1 w-full"
                     />
                 </label>

--- a/frontend/src/components/FixedCostForm.tsx
+++ b/frontend/src/components/FixedCostForm.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { FixedCost, FixedCostInput } from "@/lib/types/fixed-cost";
 import { BUSINESS_MAX_AMOUNT, FIXED_COST_NAME_MAX_LENGTH } from "@/lib/constants";
+import { AmountInput } from "@/components/ui/AmountInput";
 
 type Props = {
   fixedCost: FixedCost | null;
@@ -94,16 +95,15 @@ export function FixedCostForm({
         <label htmlFor="amount" className="block text-sm font-medium text-foreground">
           金額（円） <span className="text-danger">*</span>
         </label>
-        <input
+        <AmountInput
           id="amount"
-          type="number"
           value={amount}
-          onChange={(e) => setAmount(e.target.value)}
+          onChange={setAmount}
           disabled={isSubmitting}
-          className="w-full px-3 py-2 bg-input border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50 disabled:cursor-not-allowed"
           placeholder="10000"
-          min="1"
+          min={1}
           max={BUSINESS_MAX_AMOUNT}
+          className="w-full"
         />
       </div>
 

--- a/frontend/src/components/InitialSetupForm.tsx
+++ b/frontend/src/components/InitialSetupForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { InitialSetupRequest, FixedCostInput } from '@/lib/types/setup'
+import { AmountInput } from '@/components/ui/AmountInput'
 
 type Props = {
   onSubmit: (input: InitialSetupRequest) => Promise<void>
@@ -99,12 +100,11 @@ export function InitialSetupForm({ onSubmit, isSubmitting }: Props) {
       <div className="space-y-2">
         <label className="block text-sm font-medium text-foreground">
           月収（手取り）
-          <input
-            className="mt-1 block w-full px-3 py-2 bg-input border border-border rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
-            type="number"
+          <AmountInput
             value={income}
-            onChange={(e) => setIncome(e.target.value)}
+            onChange={setIncome}
             placeholder="例: 300000"
+            className="mt-1 w-full"
           />
         </label>
         {errors.income && <p className="text-sm text-danger">{errors.income}</p>}
@@ -113,12 +113,11 @@ export function InitialSetupForm({ onSubmit, isSubmitting }: Props) {
       <div className="space-y-2">
         <label className="block text-sm font-medium text-foreground">
           貯蓄目標（月額）
-          <input
-            className="mt-1 block w-full px-3 py-2 bg-input border border-border rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
-            type="number"
+          <AmountInput
             value={savingGoal}
-            onChange={(e) => setSavingGoal(e.target.value)}
+            onChange={setSavingGoal}
             placeholder="例: 50000"
+            className="mt-1 w-full"
           />
         </label>
         {errors.savingGoal && <p className="text-sm text-danger">{errors.savingGoal}</p>}
@@ -139,12 +138,11 @@ export function InitialSetupForm({ onSubmit, isSubmitting }: Props) {
                 />
               </div>
               <div>
-                <input
-                  className="block w-full px-3 py-2 bg-input border border-border rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
-                  type="number"
+                <AmountInput
                   value={cost.amount || ''}
-                  onChange={(e) => updateFixedCost(cost.id, 'amount', e.target.value)}
+                  onChange={(v) => updateFixedCost(cost.id, 'amount', v)}
                   placeholder="金額"
+                  className="w-full"
                 />
               </div>
               {errors.fixedCosts && errors.fixedCosts[index] && (

--- a/frontend/src/components/InitialSetupForm.tsx
+++ b/frontend/src/components/InitialSetupForm.tsx
@@ -103,6 +103,7 @@ export function InitialSetupForm({ onSubmit, isSubmitting }: Props) {
           <AmountInput
             value={income}
             onChange={setIncome}
+            disabled={isSubmitting}
             placeholder="例: 300000"
             className="mt-1 w-full"
           />
@@ -116,6 +117,7 @@ export function InitialSetupForm({ onSubmit, isSubmitting }: Props) {
           <AmountInput
             value={savingGoal}
             onChange={setSavingGoal}
+            disabled={isSubmitting}
             placeholder="例: 50000"
             className="mt-1 w-full"
           />
@@ -141,6 +143,7 @@ export function InitialSetupForm({ onSubmit, isSubmitting }: Props) {
                 <AmountInput
                   value={cost.amount || ''}
                   onChange={(v) => updateFixedCost(cost.id, 'amount', v)}
+                  disabled={isSubmitting}
                   placeholder="金額"
                   className="w-full"
                 />

--- a/frontend/src/components/MonthlySettingsModal.tsx
+++ b/frontend/src/components/MonthlySettingsModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { MonthlySettings, UpsertMonthlySettingsInput } from '@/lib/types/monthly-settings'
 import { BUSINESS_MAX_AMOUNT } from '@/lib/constants'
+import { AmountInput } from '@/components/ui/AmountInput'
 
 type MonthlySettingsModalProps = {
   isOpen: boolean
@@ -103,16 +104,14 @@ export function MonthlySettingsModal({
             <label htmlFor="ms-income" className="block text-sm font-medium text-foreground">
               手取り（月収）
             </label>
-            <input
-              type="number"
+            <AmountInput
               id="ms-income"
               value={income}
-              onChange={(e) => setIncome(Number(e.target.value))}
+              onChange={(v) => setIncome(Number(v))}
               disabled={isSubmitting}
-              min="1"
+              min={1}
               max={BUSINESS_MAX_AMOUNT}
-              required
-              className="w-full px-3 py-2 bg-input border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-full"
             />
           </div>
 
@@ -120,16 +119,14 @@ export function MonthlySettingsModal({
             <label htmlFor="ms-saving-goal" className="block text-sm font-medium text-foreground">
               目標貯金額
             </label>
-            <input
-              type="number"
+            <AmountInput
               id="ms-saving-goal"
               value={savingGoal}
-              onChange={(e) => setSavingGoal(Number(e.target.value))}
+              onChange={(v) => setSavingGoal(Number(v))}
               disabled={isSubmitting}
-              min="0"
+              min={0}
               max={BUSINESS_MAX_AMOUNT}
-              required
-              className="w-full px-3 py-2 bg-input border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-full"
             />
           </div>
 

--- a/frontend/src/components/UserForm.tsx
+++ b/frontend/src/components/UserForm.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { UpdateUserInput } from '@/lib/types/user'
 import { BUSINESS_MAX_AMOUNT } from '@/lib/constants'
+import { AmountInput } from '@/components/ui/AmountInput'
 
 type UserFormProps = {
   initialIncome?: number
@@ -55,16 +56,14 @@ export function UserForm({
         <label htmlFor="income" className="block text-sm font-medium text-foreground">
           月収（手取り）
         </label>
-        <input
-          type="number"
+        <AmountInput
           id="income"
           value={income}
-          onChange={(e) => setIncome(Number(e.target.value))}
+          onChange={(v) => setIncome(Number(v))}
           disabled={isSubmitting}
-          min="1"
+          min={1}
           max={BUSINESS_MAX_AMOUNT}
-          required
-          className="w-full px-3 py-2 bg-input border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50 disabled:cursor-not-allowed"
+          className="w-full"
         />
       </div>
 
@@ -72,16 +71,14 @@ export function UserForm({
         <label htmlFor="savingGoal" className="block text-sm font-medium text-foreground">
           貯金目標額（月）
         </label>
-        <input
-          type="number"
+        <AmountInput
           id="savingGoal"
           value={savingGoal}
-          onChange={(e) => setSavingGoal(Number(e.target.value))}
+          onChange={(v) => setSavingGoal(Number(v))}
           disabled={isSubmitting}
-          min="0"
+          min={0}
           max={BUSINESS_MAX_AMOUNT}
-          required
-          className="w-full px-3 py-2 bg-input border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50 disabled:cursor-not-allowed"
+          className="w-full"
         />
       </div>
 

--- a/frontend/src/components/ui/AmountInput.tsx
+++ b/frontend/src/components/ui/AmountInput.tsx
@@ -27,8 +27,14 @@ export function AmountInput({
   inputClassName,
 }: AmountInputProps) {
   const [isCalcOpen, setIsCalcOpen] = useState(false)
+  const [prevDisabled, setPrevDisabled] = useState(disabled)
   const wrapperRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
+
+  if (prevDisabled !== disabled) {
+    setPrevDisabled(disabled)
+    if (disabled) setIsCalcOpen(false)
+  }
 
   useEffect(() => {
     if (!isCalcOpen) return
@@ -47,7 +53,7 @@ export function AmountInput({
   }
 
   const handleApply = (val: number) => {
-    onChange(String(Math.floor(val)))
+    onChange(String(val))
     setIsCalcOpen(false)
   }
 

--- a/frontend/src/components/ui/AmountInput.tsx
+++ b/frontend/src/components/ui/AmountInput.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { Calculator } from './Calculator'
+
+type AmountInputProps = {
+  value: string | number
+  onChange: (value: string) => void
+  disabled?: boolean
+  placeholder?: string
+  min?: number
+  max?: number
+  id?: string
+  className?: string
+  inputClassName?: string
+}
+
+export function AmountInput({
+  value,
+  onChange,
+  disabled,
+  placeholder,
+  min,
+  max,
+  id,
+  className,
+  inputClassName,
+}: AmountInputProps) {
+  const [isCalcOpen, setIsCalcOpen] = useState(false)
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (!isCalcOpen) return
+    const handler = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setIsCalcOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [isCalcOpen])
+
+  const handleToggle = () => {
+    if (!isCalcOpen) inputRef.current?.blur()
+    setIsCalcOpen(prev => !prev)
+  }
+
+  const handleApply = (val: number) => {
+    onChange(String(Math.floor(val)))
+    setIsCalcOpen(false)
+  }
+
+  const initialValue = Number(value) || undefined
+
+  return (
+    <div ref={wrapperRef} className={`relative flex items-center gap-1 ${className ?? ''}`}>
+      <input
+        ref={inputRef}
+        type="number"
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        placeholder={placeholder}
+        min={min}
+        max={max}
+        className={`flex-1 min-w-0 px-3 py-2 bg-input border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50 disabled:cursor-not-allowed ${inputClassName ?? ''}`}
+      />
+      <button
+        type="button"
+        onClick={handleToggle}
+        disabled={disabled}
+        aria-label="電卓を開く"
+        aria-expanded={isCalcOpen}
+        className="shrink-0 p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <rect x="4" y="2" width="16" height="20" rx="2" ry="2"/>
+          <line x1="8" y1="6" x2="16" y2="6"/>
+          <line x1="8" y1="10" x2="10" y2="10"/>
+          <line x1="14" y1="10" x2="16" y2="10"/>
+          <line x1="8" y1="14" x2="10" y2="14"/>
+          <line x1="14" y1="14" x2="16" y2="14"/>
+          <line x1="8" y1="18" x2="10" y2="18"/>
+          <line x1="14" y1="18" x2="16" y2="18"/>
+        </svg>
+      </button>
+      {isCalcOpen && (
+        <div className="absolute top-full right-0 mt-1 z-[60]">
+          <Calculator
+            initialValue={initialValue}
+            onApply={handleApply}
+            onClose={() => setIsCalcOpen(false)}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/AmountInput.tsx
+++ b/frontend/src/components/ui/AmountInput.tsx
@@ -75,15 +75,19 @@ export function AmountInput({
         aria-expanded={isCalcOpen}
         className="shrink-0 p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
       >
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-          <rect x="4" y="2" width="16" height="20" rx="2" ry="2"/>
-          <line x1="8" y1="6" x2="16" y2="6"/>
-          <line x1="8" y1="10" x2="10" y2="10"/>
-          <line x1="14" y1="10" x2="16" y2="10"/>
-          <line x1="8" y1="14" x2="10" y2="14"/>
-          <line x1="14" y1="14" x2="16" y2="14"/>
-          <line x1="8" y1="18" x2="10" y2="18"/>
-          <line x1="14" y1="18" x2="16" y2="18"/>
+        <svg width="16" height="16" viewBox="2 1 20 22" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <rect x="3" y="2" width="18" height="20" rx="2" strokeWidth="2"/>
+          {/* + (left-top) */}
+          <line x1="6" y1="8" x2="10" y2="8"/>
+          <line x1="8" y1="6" x2="8" y2="10"/>
+          {/* - (right-top) */}
+          <line x1="14" y1="8" x2="18" y2="8"/>
+          {/* × (left-bottom) */}
+          <line x1="6" y1="14" x2="10" y2="18"/>
+          <line x1="10" y1="14" x2="6" y2="18"/>
+          {/* = (right-bottom) */}
+          <line x1="14" y1="14.5" x2="18" y2="14.5"/>
+          <line x1="14" y1="17.5" x2="18" y2="17.5"/>
         </svg>
       </button>
       {isCalcOpen && (

--- a/frontend/src/components/ui/Calculator.tsx
+++ b/frontend/src/components/ui/Calculator.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useCalculator } from '@/hooks/useCalculator'
+
+type Operator = '+' | '-' | '*' | '/'
+
+type CalculatorProps = {
+  initialValue?: number
+  onApply: (value: number) => void
+  onClose: () => void
+}
+
+export function Calculator({ initialValue, onApply, onClose }: CalculatorProps) {
+  const { display, result, handleDigit, handleOperator, handleEquals, handleClear, handleBackspace } =
+    useCalculator(initialValue)
+
+  const base = 'flex items-center justify-center min-h-[44px] rounded-lg text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring'
+  const num = `${base} bg-muted hover:bg-muted-foreground/20 text-foreground`
+  const op = `${base} bg-primary/10 hover:bg-primary/20 text-primary`
+  const eq = `${base} bg-primary hover:bg-primary-hover text-primary-foreground`
+  const ac = `${base} bg-danger/10 hover:bg-danger/20 text-danger`
+  const back = `${base} bg-muted hover:bg-muted-foreground/20 text-muted-foreground`
+
+  const digit = (d: string) => () => handleDigit(d)
+  const operator = (o: Operator) => () => handleOperator(o)
+
+  return (
+    <div className="w-60 bg-card border border-border rounded-xl shadow-lg p-3 space-y-2">
+      <div className="px-3 py-2 bg-input rounded-lg text-right font-mono text-xl text-foreground overflow-hidden whitespace-nowrap min-h-[44px] flex items-center justify-end">
+        {display}
+      </div>
+
+      <div className="grid grid-cols-4 gap-1">
+        <button type="button" onClick={handleClear} className={ac}>AC</button>
+        <button type="button" onClick={handleBackspace} className={back}>←</button>
+        <button type="button" onClick={operator('/')} className={op}>÷</button>
+        <button type="button" onClick={operator('*')} className={op}>×</button>
+
+        <button type="button" onClick={digit('7')} className={num}>7</button>
+        <button type="button" onClick={digit('8')} className={num}>8</button>
+        <button type="button" onClick={digit('9')} className={num}>9</button>
+        <button type="button" onClick={operator('-')} className={op}>−</button>
+
+        <button type="button" onClick={digit('4')} className={num}>4</button>
+        <button type="button" onClick={digit('5')} className={num}>5</button>
+        <button type="button" onClick={digit('6')} className={num}>6</button>
+        <button type="button" onClick={operator('+')} className={op}>+</button>
+
+        <button type="button" onClick={digit('1')} className={num}>1</button>
+        <button type="button" onClick={digit('2')} className={num}>2</button>
+        <button type="button" onClick={digit('3')} className={num}>3</button>
+        <button type="button" onClick={handleEquals} className={`${eq} row-span-2`}>=</button>
+
+        <button type="button" onClick={digit('0')} className={`${num} col-span-2`}>0</button>
+        <button type="button" onClick={digit('.')} className={num}>.</button>
+      </div>
+
+      <div className="flex gap-2 pt-1">
+        <button
+          type="button"
+          onClick={onClose}
+          className="flex-1 py-2 text-sm font-medium rounded-lg bg-secondary hover:bg-secondary-hover text-secondary-foreground transition-colors"
+        >
+          キャンセル
+        </button>
+        <button
+          type="button"
+          onClick={() => result !== null && onApply(result)}
+          disabled={result === null}
+          className="flex-1 py-2 text-sm font-medium rounded-lg bg-primary hover:bg-primary-hover text-primary-foreground disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          適用
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useCalculator.ts
+++ b/frontend/src/hooks/useCalculator.ts
@@ -64,7 +64,8 @@ export function useCalculator(initialValue?: number) {
       const current = parseFloat(prev.display)
       const result = applyOperator(prev.operand, prev.operator, current)
       if (result === 'error') return { ...INITIAL_STATE, display: 'エラー' }
-      return { display: String(result), operand: null, operator: null, waitingForOperand: false }
+      const rounded = Math.round(result as number)
+      return { display: String(rounded), operand: null, operator: null, waitingForOperand: false }
     })
   }
 

--- a/frontend/src/hooks/useCalculator.ts
+++ b/frontend/src/hooks/useCalculator.ts
@@ -1,0 +1,81 @@
+import { useState } from 'react'
+
+type Operator = '+' | '-' | '*' | '/'
+
+type CalcState = {
+  display: string
+  operand: number | null
+  operator: Operator | null
+  waitingForOperand: boolean
+}
+
+const INITIAL_STATE: CalcState = {
+  display: '0',
+  operand: null,
+  operator: null,
+  waitingForOperand: false,
+}
+
+function applyOperator(a: number, op: Operator, b: number): number | 'error' {
+  switch (op) {
+    case '+': return a + b
+    case '-': return a - b
+    case '*': return a * b
+    case '/': return b === 0 ? 'error' : a / b
+  }
+}
+
+export function useCalculator(initialValue?: number) {
+  const [state, setState] = useState<CalcState>(() => ({
+    ...INITIAL_STATE,
+    display: initialValue != null && !isNaN(initialValue) ? String(initialValue) : '0',
+  }))
+
+  const handleDigit = (digit: string) => {
+    setState(prev => {
+      if (prev.waitingForOperand) {
+        return { ...prev, display: digit === '.' ? '0.' : digit, waitingForOperand: false }
+      }
+      if (digit === '.' && prev.display.includes('.')) return prev
+      if (prev.display === '0' && digit !== '.') return { ...prev, display: digit }
+      return { ...prev, display: prev.display + digit }
+    })
+  }
+
+  const handleOperator = (op: Operator) => {
+    setState(prev => {
+      const current = parseFloat(prev.display)
+      if (prev.operand !== null && prev.operator && !prev.waitingForOperand) {
+        const result = applyOperator(prev.operand, prev.operator, current)
+        if (result === 'error') return { ...INITIAL_STATE, display: 'エラー' }
+        return { display: String(result), operand: result, operator: op, waitingForOperand: true }
+      }
+      return { ...prev, operand: current, operator: op, waitingForOperand: true }
+    })
+  }
+
+  const handleEquals = () => {
+    setState(prev => {
+      if (prev.operand === null || prev.operator === null) return prev
+      const current = parseFloat(prev.display)
+      const result = applyOperator(prev.operand, prev.operator, current)
+      if (result === 'error') return { ...INITIAL_STATE, display: 'エラー' }
+      return { display: String(result), operand: null, operator: null, waitingForOperand: false }
+    })
+  }
+
+  const handleClear = () => setState(INITIAL_STATE)
+
+  const handleBackspace = () => {
+    setState(prev => {
+      if (prev.waitingForOperand) return prev
+      const next = prev.display.length > 1 ? prev.display.slice(0, -1) : '0'
+      return { ...prev, display: next }
+    })
+  }
+
+  const parsed = parseFloat(state.display)
+  const result = state.display === 'エラー' || isNaN(parsed) ? null : parsed
+
+  return { display: state.display, result, handleDigit, handleOperator, handleEquals, handleClear, handleBackspace }
+}

--- a/frontend/src/hooks/useCalculator.ts
+++ b/frontend/src/hooks/useCalculator.ts
@@ -33,6 +33,9 @@ export function useCalculator(initialValue?: number) {
 
   const handleDigit = (digit: string) => {
     setState(prev => {
+      if (prev.display === 'エラー') {
+        return { ...INITIAL_STATE, display: digit === '.' ? '0.' : digit }
+      }
       if (prev.waitingForOperand) {
         return { ...prev, display: digit === '.' ? '0.' : digit, waitingForOperand: false }
       }
@@ -44,6 +47,7 @@ export function useCalculator(initialValue?: number) {
 
   const handleOperator = (op: Operator) => {
     setState(prev => {
+      if (prev.display === 'エラー') return prev
       const current = parseFloat(prev.display)
       if (prev.operand !== null && prev.operator && !prev.waitingForOperand) {
         const result = applyOperator(prev.operand, prev.operator, current)


### PR DESCRIPTION
## Summary

- `useCalculator` hook でステートマシン方式の四則演算ロジックを実装（`eval()` 不使用）
- `Calculator` コンポーネントで電卓UIを実装（ポップオーバー形式、外クリックで閉じる）
- `AmountInput` コンポーネントで既存の `<input type="number">` をラップし、電卓アイコンボタンを追加
- `ExpenseForm`、`FixedCostForm`、`InitialSetupForm`、`MonthlySettingsModal`、`UserForm` の全金額入力フィールドに適用

## Test plan

- [ ] ExpenseForm で電卓アイコンを押下 → ポップオーバーが開く
- [ ] `100 + 200 =` → 「適用」で 300 が入力される
- [ ] チェーン計算（`100 + 200 + 300 =`）が 600 になる
- [ ] ゼロ除算時に「エラー」が表示され、「適用」が無効になる
- [ ] 電卓の外クリックでポップオーバーが閉じる
- [ ] MonthlySettingsModal（モーダル内）でも電卓が正常に開閉する
- [ ] `isSubmitting` 中は電卓アイコンが disabled になる
- [ ] 既存フォームのバリデーション（min/max）が引き続き機能する

🤖 Generated with [Claude Code](https://claude.com/claude-code)